### PR TITLE
Frontend Update - UI, design

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -174,7 +174,7 @@ const headers = {
   '/parent/traits': {
     eyebrow: '학부모용 워크벤치',
     title: '아이 특성 관리',
-    copy: '가정에서 아는 강점과 어려움을 저장해 교사 추천 맥락에 보탭니다.',
+    copy: '가정에서 보이는 강점과 어려움을 기록해 학교와 같은 지원 방향을 맞춥니다.',
     search: '특성, 행동, 수준 검색',
     cta: '특성 저장',
     ctaTo: '/parent/traits',

--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -244,7 +244,7 @@ const sampleProgress = {
       created_at: '2026-04-23T10:10:00',
     },
   ],
-  progress_summary: '총 29개의 피드백 기록이 있습니다. 최근 분석 결과: 중 수준: 3회',
+  progress_summary: '',
 }
 
 const FIXED_TOMORROW_PREP = ['체육복', '색연필', '국어 공책']

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -368,21 +368,27 @@ h3 {
 
 .page-grid {
   display: grid;
-  grid-template-columns: 300px minmax(0, 1fr) 320px;
+  grid-template-columns: 330px minmax(0, 1fr) 320px;
   gap: 24px;
 }
 
+.page-grid > * {
+  min-width: 0;
+}
+
 .page-grid.two-column {
-  grid-template-columns: 300px minmax(0, 1fr);
+  grid-template-columns: 330px minmax(0, 1fr);
 }
 
 .column-stack {
   display: grid;
   align-content: start;
   gap: 24px;
+  min-width: 0;
 }
 
 .panel {
+  min-width: 0;
   border: 1px solid var(--border);
   border-radius: 8px;
   background: var(--white);
@@ -418,6 +424,22 @@ h3 {
   line-height: 17px;
 }
 
+.student-profile-subtitle {
+  display: block;
+  width: 100%;
+  overflow: visible;
+  white-space: nowrap;
+}
+
+.career-hero-subtitle {
+  white-space: normal;
+}
+
+.career-skill-title {
+  font-size: 23px;
+  white-space: nowrap;
+}
+
 .panel.dark .panel-subtitle {
   color: rgba(255, 255, 255, 0.72);
 }
@@ -427,6 +449,10 @@ h3 {
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
+}
+
+.panel-header > div {
+  min-width: 0;
 }
 
 .panel-icon {
@@ -488,8 +514,70 @@ h3 {
   line-height: 15px;
 }
 
+.student-profile-list {
+  display: grid;
+  gap: 10px;
+}
+
+.student-profile-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+  min-height: 38px;
+  gap: 8px;
+  padding: 11px 12px;
+}
+
+.student-profile-row strong {
+  white-space: nowrap;
+  line-height: 16px;
+}
+
+.student-profile-row span {
+  min-width: 0;
+  justify-self: start;
+  max-width: 100%;
+  text-align: left;
+  line-height: 18px;
+  word-break: keep-all;
+  overflow-wrap: break-word;
+  text-wrap: pretty;
+}
+
+.student-context-list {
+  display: grid;
+  gap: 12px;
+}
+
+.student-context-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+  gap: 8px;
+  min-height: 42px;
+  padding: 12px 14px;
+}
+
+.student-context-row strong {
+  white-space: nowrap;
+  line-height: 18px;
+}
+
+.student-context-row span {
+  min-width: 0;
+  justify-self: start;
+  color: var(--body);
+  font-size: 12px;
+  line-height: 1.65;
+  text-align: left;
+  word-break: keep-all;
+  overflow-wrap: break-word;
+  text-wrap: pretty;
+}
+
 .input-like,
 .textarea-like {
+  min-width: 0;
   width: 100%;
   outline: none;
   color: var(--label);
@@ -758,6 +846,10 @@ button.career-result {
   background: var(--emerald);
 }
 
+.scaffolding-result-stack {
+  margin-top: 18px;
+}
+
 .result-level {
   border-radius: 8px;
   background: var(--dark);
@@ -765,17 +857,85 @@ button.career-result {
   padding: 20px;
 }
 
-.result-level p {
-  color: rgba(255, 255, 255, 0.72);
-  font-size: 12px;
+.result-level-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
 }
 
-.result-level strong {
+.result-kicker {
+  color: rgba(255, 255, 255, 0.72);
+  font-size: 12px;
+  line-height: 18px;
+}
+
+.result-level-mark {
   display: block;
-  margin: 8px 0;
-  font-size: 40px;
+  margin-top: 7px;
+  color: var(--white);
+  font-size: 34px;
   font-weight: 300;
-  line-height: 44px;
+  line-height: 38px;
+}
+
+.result-confidence {
+  flex: 0 0 auto;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.1);
+  color: rgba(255, 255, 255, 0.9);
+  padding: 4px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 14px;
+  white-space: nowrap;
+}
+
+.result-report-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.result-report-block {
+  min-width: 0;
+  border: 1px solid rgba(255, 255, 255, 0.13);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.07);
+  padding: 13px 14px;
+}
+
+.result-report-block-wide {
+  grid-column: 1 / -1;
+}
+
+.result-report-block-primary {
+  background: rgba(255, 255, 255, 0.1);
+}
+
+.result-report-block span {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  border: 1px solid rgba(185, 185, 249, 0.24);
+  border-radius: 4px;
+  background: rgba(185, 185, 249, 0.12);
+  color: rgba(255, 255, 255, 0.9);
+  padding: 0 7px;
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 14px;
+}
+
+.result-report-block p {
+  margin-top: 9px;
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 13px;
+  line-height: 1.75;
+  word-break: keep-all;
+  overflow-wrap: break-word;
 }
 
 .strategy-grid {
@@ -797,6 +957,27 @@ button.career-result {
   color: var(--navy);
   font-size: 13px;
   line-height: 16px;
+}
+
+.strategy-card-labeled {
+  padding: 13px 14px;
+}
+
+.strategy-card-heading {
+  color: var(--purple) !important;
+  font-size: 12px !important;
+  font-weight: 600 !important;
+  line-height: 16px !important;
+}
+
+.strategy-card-copy {
+  margin-top: 8px !important;
+  color: var(--navy) !important;
+  font-size: 12px !important;
+  font-weight: 600;
+  line-height: 17px !important;
+  word-break: keep-all;
+  overflow-wrap: break-word;
 }
 
 .strategy-card p {
@@ -837,11 +1018,82 @@ button.career-result {
   align-items: center;
 }
 
+.evidence-primary {
+  position: relative;
+  padding: 16px;
+}
+
+.evidence-primary-head {
+  min-height: 24px;
+  padding-right: 58px;
+}
+
+.evidence-primary-head strong {
+  line-height: 1.35;
+  word-break: keep-all;
+  overflow-wrap: break-word;
+}
+
+.evidence-primary-score {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  color: var(--purple);
+  font-size: 15px;
+  font-weight: 700;
+  letter-spacing: 0;
+  line-height: 20px;
+  font-variant-numeric: tabular-nums;
+}
+
+.evidence-primary p {
+  margin-top: 12px;
+  color: var(--body);
+  font-size: 12px;
+  line-height: 1.7;
+  word-break: keep-all;
+  overflow-wrap: break-word;
+}
+
+.evidence-section-label {
+  margin-top: 18px;
+  margin-bottom: 18px;
+}
+
+.evidence-list {
+  gap: 12px;
+}
+
+.evidence-list.spaced {
+  margin-top: 0;
+}
+
+.evidence-result {
+  grid-template-columns: 58px minmax(0, 1fr) max-content;
+  align-items: start;
+  gap: 12px;
+  padding: 12px;
+}
+
 .standard-result code,
 .mono {
   color: var(--purple);
   font-family: 'Source Code Pro', ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 10px;
+}
+
+.evidence-result code {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 24px;
+  border-radius: 4px;
+  background: rgba(83, 58, 253, 0.08);
+  line-height: 1;
+}
+
+.evidence-result .mono {
+  line-height: 24px;
 }
 
 .standard-result strong,
@@ -850,6 +1102,12 @@ button.career-result {
   color: var(--navy);
   font-size: 13px;
   line-height: 16px;
+}
+
+.evidence-result strong {
+  line-height: 1.58;
+  word-break: keep-all;
+  overflow-wrap: break-word;
 }
 
 .standard-result p,
@@ -889,6 +1147,33 @@ button.career-result {
 .feedback-card .feedback-summary {
   margin: 0;
   line-height: 1.5;
+}
+
+.feedback-context-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+  gap: 8px;
+  padding: 12px 14px;
+  overflow-wrap: normal;
+}
+
+.feedback-context-row strong {
+  color: var(--label);
+  font-family: 'Source Code Pro', ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 18px;
+  white-space: nowrap;
+}
+
+.feedback-context-row span {
+  color: var(--body);
+  font-size: 12px;
+  line-height: 1.6;
+  text-align: left;
+  word-break: keep-all;
+  overflow-wrap: break-word;
 }
 
 .career-result {
@@ -967,10 +1252,10 @@ button.career-result {
 
 .path-stage {
   display: grid;
-  grid-template-columns: 64px minmax(0, 1fr);
-  gap: 12px;
+  grid-template-columns: 86px minmax(0, 1fr);
+  gap: 10px;
   border-left: 2px solid var(--purple-border);
-  padding: 0 0 14px 14px;
+  padding: 0 0 9px 12px;
 }
 
 .theme-parent .path-stage {
@@ -994,7 +1279,9 @@ button.career-result {
 .path-stage p {
   color: var(--body);
   font-size: 12px;
-  line-height: 17px;
+  line-height: 16px;
+  word-break: keep-all;
+  overflow-wrap: break-word;
 }
 
 .parent-path-stage {

--- a/client/src/views/parent/ParentCareerPage.vue
+++ b/client/src/views/parent/ParentCareerPage.vue
@@ -45,9 +45,9 @@
           <div>
             <p class="eyebrow">Career Hints</p>
             <h2 class="panel-title">추천 진로 후보</h2>
-            <p class="panel-subtitle">백엔드 진로 추천 결과를 학부모가 읽기 쉬운 카드로 표시합니다.</p>
+            <p class="panel-subtitle">아이의 강점과 좋아하는 활동에서 이어볼 수 있는 진로 힌트입니다.</p>
           </div>
-          <span class="badge primary">POST /rag/career-recommendation</span>
+          <span class="badge primary">진로 힌트</span>
         </div>
 
         <div class="list-stack spaced">
@@ -65,9 +65,9 @@
         <p class="eyebrow">Conversation</p>
         <h2 class="panel-title">오늘 해볼 대화</h2>
         <div class="strategy-grid spaced">
-          <article v-for="sentence in conversationPrompts" :key="sentence" class="strategy-card">
-            <strong>{{ sentence }}</strong>
-            <p>진로 이름보다 아이가 편했던 과정과 강점을 먼저 묻는 문장입니다.</p>
+          <article v-for="(sentence, index) in conversationPrompts" :key="sentence" class="strategy-card strategy-card-labeled">
+            <strong class="strategy-card-heading">대화 힌트 {{ index + 1 }}</strong>
+            <p class="strategy-card-copy">{{ sentence }}</p>
           </article>
         </div>
       </section>

--- a/client/src/views/parent/ParentOverviewPage.vue
+++ b/client/src/views/parent/ParentOverviewPage.vue
@@ -6,7 +6,7 @@
           <div>
             <p class="eyebrow">Today</p>
             <h2 class="panel-title">오늘의 학교생활</h2>
-            <p class="panel-subtitle">NEIS API를 연결하여 오늘의 학교일정을 보여줍니다.</p>
+            <p class="panel-subtitle">오늘 학교에서 확인해야 할 일정과 준비 정보를 모아 보여줍니다.</p>
           </div>
           <div class="panel-icon">
             <CalendarDays />
@@ -30,7 +30,7 @@
           <div>
             <p class="eyebrow">Home Support</p>
             <h2 class="panel-title">오늘 집에서 이어갈 일</h2>
-            <p class="panel-subtitle">교사용 기록을 가정에서 바로 해볼 수 있는 문장으로 바꿔 보여줍니다.</p>
+            <p class="panel-subtitle">학교에서 효과가 있었던 지원을 집에서도 이어갈 수 있게 정리했습니다.</p>
           </div>
           <span class="badge primary">가정 지원</span>
         </div>
@@ -60,9 +60,9 @@
         </div>
 
         <div class="strategy-grid spaced">
-          <article v-for="change in recentChanges" :key="change" class="strategy-card">
-            <strong>{{ change }}</strong>
-            <p>학교와 집에서 같은 방식으로 이어가면 변화가 더 안정적으로 보입니다.</p>
+          <article v-for="(change, index) in recentChanges" :key="change" class="strategy-card strategy-card-labeled">
+            <strong class="strategy-card-heading">변화 기록 {{ index + 1 }}</strong>
+            <p class="strategy-card-copy">{{ change }}</p>
           </article>
         </div>
       </section>
@@ -73,7 +73,7 @@
         <p class="eyebrow">Parent View</p>
         <h2 class="panel-title">학부모에게 필요한 정보</h2>
         <p class="panel-subtitle">
-          성취기준 원문이나 RAG 내부 결과보다, 오늘 일정과 집에서 할 행동을 먼저 보이게 구성했습니다.
+          학교생활, 최근 변화, 집에서 이어갈 지원을 먼저 확인할 수 있도록 정리했습니다.
         </p>
       </section>
 
@@ -122,7 +122,7 @@ import { useStudentStore } from '../../composables/useStudentStore'
 const { state: studentStore } = useStudentStore()
 
 const schoolLife = ref({})
-const progress = ref({ feedbacks: [], progress_summary: '' })
+const progress = ref({ feedbacks: [] })
 
 const todayCards = computed(() => [
   { label: '점심', value: schoolLife.value.lunch_menu || '정보 없음' },
@@ -137,8 +137,11 @@ const profileRows = computed(() => [
   { label: '특성', value: studentStore.student?.behavioral_traits || '가정 특성 입력 필요' },
 ])
 
-const progressSummary = computed(() => progress.value.progress_summary || '최근 피드백을 불러오는 중입니다.')
 const feedbacks = computed(() => progress.value.feedbacks || [])
+const progressSummary = computed(() => {
+  const count = feedbacks.value.length
+  return count > 0 ? `총 ${count}개의 피드백 기록이 있습니다.` : '아직 누적된 피드백 기록이 없습니다.'
+})
 const recentChanges = computed(() => {
   if (!feedbacks.value.length) {
     return ['그림 단서가 있을 때 집중 시간이 늘어납니다.', '활동 전환 전 예고가 있으면 불안이 줄어듭니다.']

--- a/client/src/views/parent/ParentSchoolPage.vue
+++ b/client/src/views/parent/ParentSchoolPage.vue
@@ -6,7 +6,7 @@
           <div>
             <p class="eyebrow">School Life</p>
             <h2 class="panel-title">학교생활 요약</h2>
-            <p class="panel-subtitle">NEIS 연동 정보와 fallback 데이터를 같은 화면에서 표시합니다.</p>
+            <p class="panel-subtitle">오늘 학교생활에서 확인할 일정과 준비물을 한눈에 정리합니다.</p>
           </div>
           <div class="panel-icon">
             <School />
@@ -19,10 +19,10 @@
       </section>
 
       <section class="panel dark">
-        <p class="eyebrow">Plain View</p>
-        <h2 class="panel-title">학부모 화면 기준</h2>
+        <p class="eyebrow">Daily Focus</p>
+        <h2 class="panel-title">오늘 준비 기준</h2>
         <p class="panel-subtitle">
-          급식, 시간표, 하교, 준비물처럼 오늘 행동에 필요한 정보만 전면에 둡니다.
+          등교 전 확인할 급식, 시간표, 하교 시간, 준비물을 중심으로 보여줍니다.
         </p>
       </section>
     </aside>
@@ -35,7 +35,7 @@
             <h2 class="panel-title">오늘 확인</h2>
             <p class="panel-subtitle">아침에 가장 먼저 볼 정보입니다.</p>
           </div>
-          <span class="badge primary">GET /student/school-life</span>
+          <span class="badge primary">오늘 정보</span>
         </div>
 
         <div class="metric-grid spaced">

--- a/client/src/views/parent/ParentTraitsPage.vue
+++ b/client/src/views/parent/ParentTraitsPage.vue
@@ -6,7 +6,7 @@
           <div>
             <p class="eyebrow">Child Profile</p>
             <h2 class="panel-title">아이 특성 관리</h2>
-            <p class="panel-subtitle">저장된 정보는 교사용 추천 맥락에도 반영됩니다.</p>
+            <p class="panel-subtitle">가정에서 보이는 반응을 기록해 학교와 같은 지원 방향을 맞춥니다.</p>
           </div>
           <div class="panel-icon">
             <UserRoundCog />
@@ -15,15 +15,15 @@
 
         <div class="callout spaced">
           <strong>가정에서만 아는 단서가 중요합니다.</strong>
-          <p>어려워하는 상황, 안정되는 방식, 좋아하는 활동을 짧게 적어두면 추천 품질이 좋아집니다.</p>
+          <p>어려워하는 상황, 안정되는 방식, 좋아하는 활동을 짧게 적어두면 지원 방향을 더 쉽게 맞출 수 있습니다.</p>
         </div>
       </section>
 
       <section class="panel dark">
-        <p class="eyebrow">Backend</p>
-        <h2 class="panel-title">저장 위치</h2>
+        <p class="eyebrow">Shared Support</p>
+        <h2 class="panel-title">함께 보는 특성</h2>
         <p class="panel-subtitle">
-          저장 버튼은 `PATCH /student`로 학생 프로필을 갱신합니다.
+          작성한 특성은 이후 학교와 가정의 지원 방향을 정할 때 참고됩니다.
         </p>
       </section>
     </aside>
@@ -34,9 +34,9 @@
           <div>
             <p class="eyebrow">Editable Fields</p>
             <h2 class="panel-title">프로필 입력</h2>
-            <p class="panel-subtitle">민감한 진단명보다 실제 지원에 필요한 표현을 우선합니다.</p>
+            <p class="panel-subtitle">실제 지원에 도움이 되는 표현을 우선해 적습니다.</p>
           </div>
-          <span class="badge primary">PATCH /student</span>
+          <span class="badge primary">특성 저장</span>
         </div>
 
         <div class="mini-grid spaced">
@@ -90,9 +90,9 @@
         <p class="eyebrow">Useful Examples</p>
         <h2 class="panel-title">좋은 입력 예시</h2>
         <div class="list-stack spaced">
-          <div v-for="example in examples" :key="example" class="strategy-card">
-            <strong>{{ example }}</strong>
-            <p>교사와 가정이 같은 지원 전략을 쓰는 데 도움이 됩니다.</p>
+          <div v-for="(example, index) in examples" :key="example" class="strategy-card strategy-card-labeled">
+            <strong class="strategy-card-heading">입력 예시 {{ index + 1 }}</strong>
+            <p class="strategy-card-copy">{{ example }}</p>
           </div>
         </div>
       </section>

--- a/client/src/views/teacher/TeacherCareerPage.vue
+++ b/client/src/views/teacher/TeacherCareerPage.vue
@@ -6,7 +6,7 @@
           <div>
             <p class="eyebrow">Skill Context</p>
             <h2 class="panel-title">현재 역량 입력</h2>
-            <p class="panel-subtitle">강점과 관심 활동을 입력하면 AI가 맞춤 진로를 추천합니다.</p>
+            <p class="panel-subtitle career-hero-subtitle">강점과 관심 활동을 입력하면 AI가 맞춤 진로를 추천합니다.</p>
           </div>
           <div class="panel-icon">
             <Sparkles />
@@ -33,8 +33,8 @@
       <section class="panel">
         <p class="eyebrow">Student</p>
         <h2 class="panel-title">학생 맥락</h2>
-        <div class="list-stack spaced">
-          <div v-for="item in profileRows" :key="item.label" class="card-row">
+        <div class="list-stack spaced student-context-list">
+          <div v-for="item in profileRows" :key="item.label" class="card-row student-context-row">
             <strong>{{ item.label }}</strong>
             <span>{{ item.value }}</span>
           </div>
@@ -95,7 +95,7 @@
         <div class="panel-header">
           <div>
             <p class="eyebrow">Development</p>
-            <h2 class="panel-title">키우기 제안</h2>
+            <h2 class="panel-title">역량 성장 제안</h2>
           </div>
           <span class="badge soft">{{ selectedCareerTitle }}</span>
         </div>
@@ -117,7 +117,7 @@
         <div class="panel-header">
           <div>
             <p class="eyebrow">Skill Gap</p>
-            <h2 class="panel-title">수업으로 키울 역량</h2>
+            <h2 class="panel-title career-skill-title">수업으로 키울 역량</h2>
           </div>
           <span class="badge soft">{{ selectedCareerTitle }}</span>
         </div>

--- a/client/src/views/teacher/TeacherOverviewPage.vue
+++ b/client/src/views/teacher/TeacherOverviewPage.vue
@@ -6,15 +6,15 @@
           <div>
             <p class="eyebrow">Student Profile</p>
             <h2 class="panel-title">{{ studentName }}</h2>
-            <p class="panel-subtitle">AI가 답변 생성시 학생의 기본 특성을 반영합니다.</p>
           </div>
           <div class="panel-icon">
             <UserRoundCheck />
           </div>
         </div>
+        <p class="panel-subtitle student-profile-subtitle">AI가 답변 생성시 학생의 기본 특성을 반영합니다.</p>
 
-        <div class="list-stack spaced">
-          <div v-for="item in studentCards" :key="item.label" class="card-row">
+        <div class="list-stack spaced student-profile-list">
+          <div v-for="item in studentCards" :key="item.label" class="card-row student-profile-row">
             <strong>{{ item.label }}</strong>
             <span>{{ item.value }}</span>
           </div>
@@ -117,20 +117,39 @@
         </div>
 
         <template v-if="quickRecommendation">
-          <div class="space-y-6 pt-1">
+          <div class="scaffolding-result-stack space-y-6">
             <div class="result-level">
-              <p>감지된 지원 수준</p>
-              <strong>{{ levelLabel(quickRecommendation.recommended_level) }}</strong>
-              <p class="mt-3 text-sm leading-relaxed text-[var(--color-text-secondary)]">
-                {{ levelSemantics(quickRecommendation.recommended_level) }}
-              </p>
-              <p class="mt-4 leading-relaxed">{{ quickRecommendation.rationale }}</p>
+              <div class="result-level-header">
+                <div>
+                  <p class="result-kicker">감지된 지원 수준</p>
+                  <strong class="result-level-mark">{{ levelLabel(quickRecommendation.recommended_level) }}</strong>
+                </div>
+                <span v-if="recommendationConfidence" class="result-confidence">
+                  신뢰도 {{ recommendationConfidence }}
+                </span>
+              </div>
+
+              <div class="result-report-grid">
+                <article class="result-report-block result-report-block-primary">
+                  <span>평가 요약</span>
+                  <p>{{ levelSemantics(quickRecommendation.recommended_level) }}</p>
+                  <p v-if="rationaleSections.assessment">{{ rationaleSections.assessment }}</p>
+                </article>
+                <article v-if="rationaleSections.gap" class="result-report-block">
+                  <span>주요 학습 격차</span>
+                  <p>{{ rationaleSections.gap }}</p>
+                </article>
+                <article v-if="rationaleSections.standard" class="result-report-block result-report-block-wide">
+                  <span>근거 성취기준</span>
+                  <p>{{ rationaleSections.standard }}</p>
+                </article>
+              </div>
             </div>
 
             <div class="strategy-grid spaced gap-y-6">
-              <article v-for="strategy in strategies" :key="strategy" class="strategy-card">
-                <strong>{{ strategy }}</strong>
-                <p class="mt-2 leading-relaxed">수업 장면에서 바로 실행할 수 있는 단위로 정리했습니다.</p>
+              <article v-for="(strategy, index) in strategies" :key="strategy" class="strategy-card strategy-card-labeled">
+                <strong class="strategy-card-heading">추천 전략 {{ index + 1 }}</strong>
+                <p class="strategy-card-copy">{{ strategy }}</p>
               </article>
             </div>
           </div>
@@ -152,11 +171,6 @@
         </div>
 
         <template v-if="quickRecommendation">
-          <p
-            class="mb-4 border-b border-[var(--color-border)] pb-3 text-xs font-medium uppercase tracking-wide text-[var(--color-text-secondary)]"
-          >
-            실행 단위 활동 · 지적 처리 부담을 줄이고 한 번에 하나씩 완료할 수 있게 구성했습니다 (지훈이 맞춤).
-          </p>
           <div class="strategy-grid spaced gap-y-6">
             <article
               v-for="activity in activities"
@@ -198,32 +212,31 @@
           </div>
         </div>
 
-        <div v-if="standard" class="callout spaced">
-          <div class="flex flex-wrap items-start justify-between gap-3">
-            <strong class="min-w-0 flex-1 leading-snug">
+        <div v-if="standard" class="callout spaced evidence-primary">
+          <div class="evidence-primary-head">
+            <strong>
               {{ standard.standard_id || '기준 ID 없음' }} · {{ standard.subject || recommendationForm.subject }}
             </strong>
             <span
-              class="shrink-0 text-2xl font-bold tabular-nums tracking-tight text-[var(--color-primary,#4f46e5)]"
+              class="evidence-primary-score"
               title="AI 분석 기준 문헌·검색 일치도"
             >
               {{ primaryMatchPercent }}
             </span>
           </div>
-          <p class="mt-3 leading-relaxed">{{ standard.standard_text }}</p>
+          <p>{{ standard.standard_text }}</p>
         </div>
         <div v-else class="empty-state spaced">
           <strong>추천 결과 대기</strong>
           <p>추천 실행 후 가장 관련도 높은 기준이 표시됩니다.</p>
         </div>
 
-        <p v-if="evidenceList.length" class="eyebrow mt-4">함께 본 기준</p>
-        <div v-if="evidenceList.length" class="list-stack spaced">
-          <article v-for="(row, index) in evidenceList" :key="`${row.text}-${index}`" class="standard-result items-start gap-3">
+        <p v-if="evidenceList.length" class="eyebrow evidence-section-label">함께 본 기준</p>
+        <div v-if="evidenceList.length" class="list-stack spaced evidence-list">
+          <article v-for="(row, index) in evidenceList" :key="`${row.text}-${index}`" class="standard-result evidence-result">
             <code class="shrink-0">{{ `REL ${String(index + 1).padStart(2, '0')}` }}</code>
             <div class="min-w-0 flex-1">
-              <strong class="line-clamp-2">{{ row.text }}</strong>
-              <p class="mt-1 text-sm text-[var(--color-text-secondary)]">AI 매칭 스코어 기준 참고 항목입니다.</p>
+              <strong>{{ row.text }}</strong>
             </div>
             <span class="mono shrink-0 text-base font-semibold tabular-nums">{{ row.matchPercent }}</span>
           </article>
@@ -280,7 +293,10 @@ const studentCards = computed(() => [
 ])
 
 const feedbacks = computed(() => progress.value.feedbacks || [])
-const progressSummary = computed(() => progress.value.progress_summary || '최근 피드백을 불러오는 중입니다.')
+const progressSummary = computed(() => {
+  const count = feedbacks.value.length
+  return count > 0 ? `총 ${count}개의 피드백 기록이 있습니다.` : '아직 누적된 피드백 기록이 없습니다.'
+})
 const latestFeedback = computed(() => feedbacks.value.at(-1) || null)
 const latestLevel = computed(() => latestFeedback.value?.llm_analysis?.detected_level || '중')
 
@@ -312,6 +328,35 @@ const primaryMatchPercent = computed(() =>
   scoreToPercent(standard.value?.relevance_score ?? standard.value?.match_score),
 )
 
+const recommendationConfidence = computed(() => {
+  const rec = quickRecommendation.value
+  const direct =
+    rec?.confidence_score ??
+    rec?.confidence ??
+    rec?.llm_analysis?.confidence_score ??
+    rec?.analysis?.confidence_score
+  if (direct != null && direct !== '') {
+    const n = Number(direct)
+    return Number.isNaN(n) ? String(direct) : n <= 1 ? n.toFixed(2) : `${Math.round(n)}%`
+  }
+
+  const match = String(rec?.rationale || '').match(/신뢰도\s*[:：]\s*([0-9]+(?:\.[0-9]+)?%?)/)
+  return match?.[1] || ''
+})
+
+const displayRationale = computed(() => {
+  const raw = String(quickRecommendation.value?.rationale || '')
+  return raw
+    .split('\n')
+    .filter((line) => !/^신뢰도\s*[:：]/.test(line.trim()))
+    .join('\n')
+    .trim()
+})
+
+const rationaleSections = computed(() =>
+  parseRationaleSections(displayRationale.value, levelSemantics(quickRecommendation.value?.recommended_level)),
+)
+
 const evidenceList = computed(() => {
   const rec = quickRecommendation.value
   if (!rec?.related_achievement_standards?.length) return []
@@ -336,7 +381,7 @@ const evidenceList = computed(() => {
       }
 
       return {
-        text,
+        text: stripRelatedScoreText(text),
         matchPercent: scoreToPercent(matchRaw),
       }
     })
@@ -367,6 +412,52 @@ function scoreToPercent(raw) {
 
 function isPlaceholderRelatedText(text) {
   return /추천 생성 후|후보가 여기/.test(text)
+}
+
+function stripRelatedScoreText(text) {
+  return String(text || '').replace(/\s*\(관련도\s*[0-9]+(?:\.[0-9]+)?\)\s*$/g, '').trim()
+}
+
+function parseRationaleSections(text, semanticText = '') {
+  const sections = {
+    assessment: '',
+    gap: '',
+    standard: '',
+  }
+  let current = 'assessment'
+
+  String(text || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .forEach((line) => {
+      if (semanticText && line === semanticText.trim()) return
+
+      const gapMatch = line.match(/^주요 학습 격차\s*[:：]\s*(.*)$/)
+      if (gapMatch) {
+        current = 'gap'
+        sections.gap = appendSentence(sections.gap, gapMatch[1])
+        return
+      }
+
+      const standardMatch = line.match(/^관련 성취기준\s*[:：]\s*(.*)$/)
+      if (standardMatch) {
+        current = 'standard'
+        sections.standard = appendSentence(sections.standard, standardMatch[1])
+        return
+      }
+
+      if (/^[상중하]\s*[:：]/.test(line)) return
+      sections[current] = appendSentence(sections[current], line)
+    })
+
+  return sections
+}
+
+function appendSentence(base, next) {
+  const value = String(next || '').trim()
+  if (!value) return base
+  return base ? `${base} ${value}` : value
 }
 
 function levelSemantics(level) {

--- a/client/src/views/teacher/TeacherProgressPage.vue
+++ b/client/src/views/teacher/TeacherProgressPage.vue
@@ -23,10 +23,10 @@
       </section>
 
       <section class="panel dark">
-        <p class="eyebrow">Stored in Database</p>
-        <h2 class="panel-title">기록 출처</h2>
+        <p class="eyebrow">Learning Memory</p>
+        <h2 class="panel-title">누적 관찰 메모</h2>
         <p class="panel-subtitle">
-          스캐폴딩 추천을 실행하면 데이터 베이스에 관찰 기록 및 추천 활동이 저장됩니다. 이 내역들은 추후 스캐폴딩 제공에 반영됩니다.
+          저장된 피드백은 다음 추천을 만들 때 학생의 반응 패턴과 지원 이력으로 함께 반영됩니다.
         </p>
       </section>
     </aside>
@@ -119,12 +119,15 @@ import { getStudentProgress, mapLevelToKorean } from '../../api'
 
 const loading = ref(false)
 const feedbacks = ref([])
-const progressSummary = ref('최근 피드백을 불러오는 중입니다.')
 const selectedId = ref(null)
 
 const orderedFeedbacks = computed(() => [...feedbacks.value].reverse())
 const selectedFeedback = computed(() => feedbacks.value.find((feedback) => feedback.id === selectedId.value) || orderedFeedbacks.value[0] || null)
 const latestLevel = computed(() => selectedFeedback.value?.llm_analysis?.detected_level || '중')
+const progressSummary = computed(() => {
+  const count = feedbacks.value.length
+  return count > 0 ? `총 ${count}개의 피드백 기록이 있습니다.` : '아직 누적된 피드백 기록이 없습니다.'
+})
 
 const metrics = computed(() => [
   { label: '총 기록', value: feedbacks.value.length, caption: 'Feedback rows' },
@@ -174,7 +177,6 @@ async function loadProgress() {
   try {
     const progress = await getStudentProgress()
     feedbacks.value = progress.feedbacks || []
-    progressSummary.value = progress.progress_summary || '아직 피드백 데이터가 없습니다.'
     selectedId.value = orderedFeedbacks.value[0]?.id || null
   } finally {
     loading.value = false

--- a/client/src/views/teacher/TeacherScaffoldingPage.vue
+++ b/client/src/views/teacher/TeacherScaffoldingPage.vue
@@ -4,17 +4,17 @@
       <section class="panel">
         <div class="panel-header">
           <div>
-            <p class="eyebrow">Student</p>
+            <p class="eyebrow">Student Profile</p>
             <h2 class="panel-title">{{ studentName }}</h2>
-            <p class="panel-subtitle">학생 맥락은 추천 요청과 함께 서버에서 반영됩니다.</p>
           </div>
           <div class="panel-icon">
             <UserRoundCog />
           </div>
         </div>
+        <p class="panel-subtitle student-profile-subtitle">학생의 기본 특성과 현재 수준을 바탕으로 추천 방향을 잡습니다.</p>
 
-        <div class="list-stack spaced">
-          <div v-for="item in studentProfile" :key="item.label" class="card-row">
+        <div class="list-stack spaced student-context-list">
+          <div v-for="item in studentProfile" :key="item.label" class="card-row student-context-row">
             <strong>{{ item.label }}</strong>
             <span>{{ item.value }}</span>
           </div>
@@ -24,10 +24,14 @@
       <section class="panel">
         <p class="eyebrow">Past Feedback</p>
         <h2 class="panel-title">최근 기록 반영</h2>
-        <p class="panel-subtitle">선택한 피드백 ID는 추천 요청의 맥락으로 보낼 수 있습니다.</p>
+        <p class="panel-subtitle">최근 관찰 기록을 함께 참고해 반복되는 어려움과 반응을 반영합니다.</p>
 
         <div class="list-stack spaced">
-          <label v-for="feedback in feedbacks.slice(-3).reverse()" :key="feedback.id" class="card-row">
+          <label
+            v-for="feedback in feedbacks.slice(-3).reverse()"
+            :key="feedback.id"
+            class="card-row feedback-context-row"
+          >
             <strong>{{ formatDate(feedback.created_at) }}</strong>
             <span>{{ feedback.teacher_description || feedback.performance || '기록 내용 없음' }}</span>
           </label>
@@ -41,9 +45,9 @@
           <div>
             <p class="eyebrow">Observation Input</p>
             <h2 class="panel-title">스캐폴딩 추천 입력</h2>
-            <p class="panel-subtitle">관찰 문장과 과목 정보를 서버의 추천 API로 전송합니다.</p>
+            <p class="panel-subtitle">수업 중 관찰한 상황을 적으면 바로 적용할 지원 방향을 정리합니다.</p>
           </div>
-          <span class="badge primary">POST /rag</span>
+          <span class="badge primary">맞춤 추천</span>
         </div>
 
         <div class="mini-grid spaced">
@@ -80,15 +84,34 @@
 
       <section class="panel" v-if="recommendation">
         <div class="result-level">
-          <p>감지된 지원 수준</p>
-          <strong>{{ levelLabel(recommendation.recommended_level) }}</strong>
-          <p>{{ recommendation.rationale }}</p>
+          <div class="result-level-header">
+            <div>
+              <p class="result-kicker">감지된 지원 수준</p>
+              <strong class="result-level-mark">{{ levelLabel(recommendation.recommended_level) }}</strong>
+            </div>
+          </div>
+
+          <div class="result-report-grid">
+            <article class="result-report-block result-report-block-primary">
+              <span>평가 요약</span>
+              <p>{{ detailLevelSemantics }}</p>
+              <p v-if="detailRationaleSections.assessment">{{ detailRationaleSections.assessment }}</p>
+            </article>
+            <article v-if="detailRationaleSections.gap" class="result-report-block">
+              <span>주요 학습 격차</span>
+              <p>{{ detailRationaleSections.gap }}</p>
+            </article>
+            <article v-if="detailRationaleSections.standard" class="result-report-block result-report-block-wide">
+              <span>근거 성취기준</span>
+              <p>{{ detailRationaleSections.standard }}</p>
+            </article>
+          </div>
         </div>
 
         <div class="strategy-grid spaced">
-          <article v-for="strategy in strategies" :key="strategy" class="strategy-card">
-            <strong>{{ strategy }}</strong>
-            <p>수업 장면에서 바로 실행할 수 있는 단위로 정리했습니다.</p>
+          <article v-for="(strategy, index) in strategies" :key="strategy" class="strategy-card strategy-card-labeled">
+            <strong class="strategy-card-heading">추천 전략 {{ index + 1 }}</strong>
+            <p class="strategy-card-copy">{{ strategy }}</p>
           </article>
         </div>
       </section>
@@ -96,7 +119,7 @@
       <section class="panel" v-else>
         <div class="empty-state">
           <strong>추천 결과가 아직 없습니다.</strong>
-          <p>관찰 기록을 입력하고 추천을 실행하면 수준, 전략, 활동, 근거가 이 화면에 나타납니다.</p>
+          <p>관찰 기록을 입력하면 추천 수준, 지원 전략, 활동, 근거 기준을 한 번에 확인할 수 있습니다.</p>
         </div>
       </section>
 
@@ -120,15 +143,15 @@
 
     <aside class="column-stack">
       <section class="panel dark">
-        <p class="eyebrow">Recommendation Logic</p>
-        <h2 class="panel-title">서버 연계 흐름</h2>
-        <p class="panel-subtitle">이 화면에서 실행하면 백엔드가 추천을 만들고 피드백 기록에도 저장합니다.</p>
+        <p class="eyebrow">Recommendation Flow</p>
+        <h2 class="panel-title">추천 구성 방식</h2>
+        <p class="panel-subtitle">입력한 관찰 기록을 학생 특성, 지난 피드백, 성취기준과 함께 보며 수업 지원 방향을 정리합니다.</p>
 
         <div class="list-stack spaced">
-          <div class="dark-list-item">1. 학생 프로필 조회</div>
-          <div class="dark-list-item">2. 관찰 기록 RAG 분석</div>
-          <div class="dark-list-item">3. 성취기준 근거 연결</div>
-          <div class="dark-list-item">4. 추천 결과 피드백 저장</div>
+          <div class="dark-list-item">1. 학생 특성 확인</div>
+          <div class="dark-list-item">2. 최근 관찰 기록 반영</div>
+          <div class="dark-list-item">3. 관련 성취기준 확인</div>
+          <div class="dark-list-item">4. 수업 전략과 활동 제안</div>
         </div>
       </section>
 
@@ -141,7 +164,7 @@
         </div>
         <div v-else class="empty-state spaced">
           <strong>기준 대기</strong>
-          <p>추천 실행 후 가장 관련도 높은 기준이 표시됩니다.</p>
+          <p>학생 상태와 가장 가까운 성취기준이 여기에 표시됩니다.</p>
         </div>
       </section>
 
@@ -200,15 +223,73 @@ const activities = computed(() =>
 )
 
 const standard = computed(() => recommendation.value?.achievement_standard || null)
+const detailLevelSemantics = computed(() => levelSemantics(recommendation.value?.recommended_level))
+const detailRationaleSections = computed(() =>
+  parseRationaleSections(recommendation.value?.rationale, detailLevelSemantics.value),
+)
 const relatedStandards = computed(() =>
   recommendation.value?.related_achievement_standards?.length
     ? recommendation.value.related_achievement_standards
-    : ['추천 실행 후 관련 성취기준 후보가 여기에 표시됩니다.'],
+    : ['추천과 함께 참고할 성취기준이 여기에 표시됩니다.'],
 )
 
 function levelLabel(level) {
   const mapped = mapLevelToKorean(level)
   return mapped != null && mapped !== '' ? mapped : '대기'
+}
+
+function levelSemantics(level) {
+  const mapped = mapLevelToKorean(level)
+  const key = String(mapped || '').trim()
+  if (key === '중')
+    return '중: 시각적 단서와 단계별 안내를 병행하면 과제를 이어가기 쉬운 수준입니다.'
+  if (key === '상')
+    return '상: 상대적으로 독립 수행에 가깝고, 확인 질문·선택지 중심의 가벼운 지원으로 충분한 경우가 많습니다.'
+  if (key === '하')
+    return '하: 세분화된 시각·구체 자료와 짧은 단계의 안내가 필요한 수준입니다.'
+  return '추천 수준에 따른 지원 강도입니다.'
+}
+
+function parseRationaleSections(text, semanticText = '') {
+  const sections = {
+    assessment: '',
+    gap: '',
+    standard: '',
+  }
+  let current = 'assessment'
+
+  String(text || '')
+    .split('\n')
+    .map((line) => line.trim())
+    .filter((line) => line && !/^신뢰도\s*[:：]/.test(line))
+    .forEach((line) => {
+      if (semanticText && line === semanticText.trim()) return
+
+      const gapMatch = line.match(/^주요 학습 격차\s*[:：]\s*(.*)$/)
+      if (gapMatch) {
+        current = 'gap'
+        sections.gap = appendSentence(sections.gap, gapMatch[1])
+        return
+      }
+
+      const standardMatch = line.match(/^관련 성취기준\s*[:：]\s*(.*)$/)
+      if (standardMatch) {
+        current = 'standard'
+        sections.standard = appendSentence(sections.standard, standardMatch[1])
+        return
+      }
+
+      if (/^[상중하]\s*[:：]/.test(line)) return
+      sections[current] = appendSentence(sections[current], line)
+    })
+
+  return sections
+}
+
+function appendSentence(base, next) {
+  const value = String(next || '').trim()
+  if (!value) return base
+  return base ? `${base} ${value}` : value
 }
 
 function formatDate(value) {


### PR DESCRIPTION
## 작업 내용

- `client` 폴더의 프론트엔드 UI를 최신 디자인 기준으로 업데이트했습니다.
- 교사용 대시보드, 추천, 기준, 기록, 진로 화면의 레이아웃과 문구를 개선했습니다.
- 학부모용 홈, 학교생활, 특성, 진로 화면을 모바일 중심 UI로 정리했습니다.
- 학생 프로필, 추천 결과, 근거 성취기준, 최근 기록, 진로 추천 영역의 가독성을 개선했습니다.
- 실제 API 응답 구조를 반영하여 화면 데이터 표시 방식을 정리했습니다.

## 주요 변경 사항

- 반복되거나 기술적으로 보이는 문구를 서비스 화면에 맞는 표현으로 수정
- 추천 전략 영역에 `추천 전략 1~4` 구조 적용
- 피드백 개수 표시를 실제 데이터 기반으로 변경
- 카드 간격, 줄바꿈, 정렬, 모바일 표시 문제 개선
- 교사용/학부모용 라우팅 및 탭별 상세 화면 UI 정리

## 확인 사항

- 이번 PR은 `client` 폴더 변경만 포함합니다.
- 서버 로직 변경은 포함하지 않았습니다.
- 로컬에서 프론트엔드 빌드 확인 완료

```bash
npm run build