### PR TITLE
Updating UI & Design

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -97,29 +97,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1085,6 +1062,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1992,6 +1970,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -2220,6 +2199,7 @@
       "integrity": "sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -2297,6 +2277,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
       "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.32",
         "@vue/compiler-sfc": "3.5.32",

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -12,10 +12,16 @@
         </div>
       </div>
 
-      <div class="topbar-actions">
+      <form class="topbar-actions" @submit.prevent="runGlobalSearch">
         <label class="global-search">
           <Search class="search-icon" />
-          <input type="search" :placeholder="header.search" />
+          <input
+            v-model="globalSearchQuery"
+            type="search"
+            :placeholder="header.search"
+            @keydown.enter.prevent="runGlobalSearch"
+            @search="runGlobalSearch"
+          />
         </label>
         <RouterLink
           v-for="mode in roleModes"
@@ -25,10 +31,11 @@
         >
           {{ mode.label }}
         </RouterLink>
-        <RouterLink :to="header.ctaTo" class="primary-action">
-          {{ header.cta }}
-        </RouterLink>
-      </div>
+      </form>
+
+      <RouterLink :to="alternateRoleMode.to" class="mobile-role-switch">
+        {{ alternateRoleMode.label }}
+      </RouterLink>
     </header>
 
     <div class="workspace">
@@ -37,10 +44,10 @@
           v-for="item in navItems"
           :key="item.to"
           :to="item.to"
+          :aria-label="item.label"
           :class="['rail-item', route.path === item.to && 'is-active']"
         >
           <component :is="item.icon" />
-          <span>{{ item.label }}</span>
         </RouterLink>
         <div class="rail-avatar">{{ isTeacherRoute ? '지훈' : '지훈' }}</div>
       </aside>
@@ -66,8 +73,8 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
-import { RouterLink, RouterView, useRoute } from 'vue-router'
+import { computed, onMounted, ref, watch } from 'vue'
+import { RouterLink, RouterView, useRoute, useRouter } from 'vue-router'
 import {
   BarChart3,
   BookOpenCheck,
@@ -93,7 +100,9 @@ import teacherCriteriaSvg from './assets/icons/criteria.svg?raw'
 import teacherRecordSvg from './assets/icons/record.svg?raw'
 
 const route = useRoute()
+const router = useRouter()
 const { state: studentStore, loadStudent } = useStudentStore()
+const globalSearchQuery = ref('')
 
 const isTeacherRoute = computed(() => route.path.startsWith('/teacher'))
 
@@ -120,72 +129,54 @@ const headers = {
     title: '대시보드',
     copy: '관찰 기록을 바탕으로 한 AI 스캐폴딩 추천과 근거 기준, 학생 성장 흐름을 한눈에 확인합니다.',
     search: '학생, 성취기준, 피드백 검색',
-    cta: '추천 작성',
-    ctaTo: '/teacher/scaffolding',
   },
   '/teacher/scaffolding': {
     eyebrow: '교사용 워크벤치 · 추천 상세 화면',
     title: 'AI 스캐폴딩 추천',
     copy: '관찰 기록을 입력하고 학생 맥락과 과거 피드백을 반영해 지원 전략을 생성합니다.',
     search: '학생, 피드백, 추천 기록 검색',
-    cta: '추천 생성',
-    ctaTo: '/teacher/scaffolding',
   },
   '/teacher/curriculum': {
     eyebrow: '교사용 워크벤치 · 기준 상세 화면',
     title: '성취기준 근거 검색',
     copy: '국어와 수학 성취기준을 검색하고 AI 추천의 근거로 사용할 기준을 선택합니다.',
     search: '성취기준, 과목, 키워드 검색',
-    cta: '기준 검색',
-    ctaTo: '/teacher/curriculum',
   },
   '/teacher/progress': {
     eyebrow: '교사용 워크벤치 · 기록 상세 화면',
     title: '피드백 기록과 성장 흐름',
     copy: 'AI 추천 실행 후 저장된 피드백을 학생별 타임라인과 요약으로 확인합니다.',
     search: '날짜, 수준, 피드백 검색',
-    cta: '기록 보기',
-    ctaTo: '/teacher/progress',
   },
   '/teacher/career': {
     eyebrow: '교사용 워크벤치 · 진로 상세 화면',
     title: '강점 기반 진로 추천',
     copy: '학생의 현재 역량과 관심 단서를 바탕으로 진로 후보와 역량 격차를 확인합니다.',
     search: '직업, 강점, 역량 검색',
-    cta: '진로 탐색',
-    ctaTo: '/teacher/career',
   },
   '/parent/overview': {
     eyebrow: '학부모용 워크벤치',
     title: '대시보드',
     copy: '학교생활 정보와 최근 피드백을 쉬운 문장으로 보고, 집에서 바로 해볼 일을 확인합니다.',
     search: '학교생활, 강점, 진로 검색',
-    cta: '기록 보기',
-    ctaTo: '/parent/overview',
   },
   '/parent/school': {
     eyebrow: '학부모용 워크벤치',
     title: '학교생활 상세',
     copy: '급식, 시간표, 하교 시간, 내일 준비를 빠르게 확인합니다.',
     search: '급식, 시간표, 일정 검색',
-    cta: '새로고침',
-    ctaTo: '/parent/school',
   },
   '/parent/traits': {
     eyebrow: '학부모용 워크벤치',
     title: '아이 특성 관리',
     copy: '가정에서 보이는 강점과 어려움을 기록해 학교와 같은 지원 방향을 맞춥니다.',
     search: '특성, 행동, 수준 검색',
-    cta: '특성 저장',
-    ctaTo: '/parent/traits',
   },
   '/parent/career': {
     eyebrow: '학부모용 워크벤치',
     title: '강점과 진로',
     copy: '아이의 강점과 좋아하는 활동을 부담 없는 진로 대화로 연결합니다.',
     search: '관심 활동, 직업 검색',
-    cta: '탐색',
-    ctaTo: '/parent/career',
   },
 }
 
@@ -195,6 +186,45 @@ const roleModes = computed(() => [
   { to: '/teacher/overview', label: '교사용', active: isTeacherRoute.value },
   { to: '/parent/overview', label: '학부모용', active: !isTeacherRoute.value },
 ])
+
+const roleSwitchTargets = {
+  '/teacher/overview': '/parent/overview',
+  '/teacher/career': '/parent/career',
+  '/parent/overview': '/teacher/overview',
+  '/parent/career': '/teacher/career',
+}
+
+const alternateRoleMode = computed(() => ({
+  to: roleSwitchTargets[route.path] || (isTeacherRoute.value ? '/parent/overview' : '/teacher/overview'),
+  label: isTeacherRoute.value ? '학부모용' : '교사용',
+}))
+
+function getSearchTargetPath(query = '') {
+  if (route.path.includes('/career')) return isTeacherRoute.value ? '/teacher/career' : '/parent/career'
+  if (route.path === '/teacher/progress') return '/teacher/progress'
+  if (route.path === '/teacher/curriculum') return '/teacher/curriculum'
+  if (isTeacherRoute.value) {
+    if (/진로|직업|강점|역량|관심|활동/.test(query)) return '/teacher/career'
+    if (/피드백|기록|수준|날짜|변화/.test(query)) return '/teacher/progress'
+    return '/teacher/curriculum'
+  }
+  return '/parent/career'
+}
+
+function runGlobalSearch() {
+  const q = globalSearchQuery.value.trim()
+  const targetPath = getSearchTargetPath(q)
+  const nextQuery = q ? { q } : {}
+  router.push({ path: targetPath, query: nextQuery })
+}
+
+watch(
+  () => route.query.q,
+  (q) => {
+    globalSearchQuery.value = typeof q === 'string' ? q : ''
+  },
+  { immediate: true },
+)
 
 onMounted(loadStudent)
 </script>

--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -2,7 +2,7 @@ import axios from 'axios'
 
 const apiClient = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000',
-  timeout: 10000,
+  timeout: 180000,
 })
 
 /** 서버 레벨 토큰 → UI용 한글 (상·중·하) */
@@ -22,20 +22,162 @@ export function mapLevelTokensInString(text) {
   return text.replace(/\bhigh\b/gi, '상').replace(/\bmedium\b/gi, '중').replace(/\blow\b/gi, '하')
 }
 
+function cleanDisplayText(text) {
+  return mapLevelTokensInString(String(text || ''))
+    .replace(/\r\n?/g, '\n')
+    .split('\n')
+    .map((line) => line.trim().replace(/^(?:[-*•·]\s*|\d+[.)]\s*)+/, ''))
+    .filter(Boolean)
+    .join(' ')
+    .replace(/\s*([?!])\s*,+\s*/g, '$1 ')
+    .replace(/\s*\.\s*,\s*/g, '. ')
+    .replace(/\s*,\s*,+\s*/g, ', ')
+    .replace(/^[,;:\s]+|[,;:\s]+$/g, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+}
+
+function appendTextFragment(base, next) {
+  const value = cleanDisplayText(next)
+  if (!value) return base
+  return base ? `${base} ${value}` : value
+}
+
+function normalizeRationaleForParsing(text) {
+  return mapLevelTokensInString(String(text || ''))
+    .replace(/\r\n?/g, '\n')
+    .replace(/\s*(?=(?:평가\s*요약|분석\s*요약|주요\s*학습\s*격차|관련\s*성취기준|근거\s*성취기준|신뢰도)\s*[:：])/g, '\n')
+    .split('\n')
+    .map((line) => line.trim().replace(/^(?:[-*•·]\s*|\d+[.)]\s*)+/, ''))
+    .filter(Boolean)
+}
+
+function formatConfidenceValue(value) {
+  if (value == null || value === '') return ''
+  const raw = String(value).trim()
+  if (!raw) return ''
+  if (raw.endsWith('%')) return raw
+  const numeric = Number(raw)
+  if (Number.isNaN(numeric)) return raw
+  return numeric <= 1 ? numeric.toFixed(2) : `${Math.round(numeric)}%`
+}
+
+function extractConfidenceFromText(text) {
+  const match = String(text || '').match(/신뢰도\s*[:：]\s*([0-9]+(?:\.[0-9]+)?%?)/)
+  return formatConfidenceValue(match?.[1])
+}
+
+function getLearningGapText(analysis, rec) {
+  const candidates = [
+    analysis?.learning_gaps,
+    rec?.learning_gaps,
+    rec?.analysis?.learning_gaps,
+  ]
+  const gapList = candidates.find((value) => Array.isArray(value) && value.length)
+  if (gapList) {
+    return gapList.map((item) => cleanDisplayText(item)).filter(Boolean).join(' · ')
+  }
+  return ''
+}
+
+function getStandardDisplayText(standard) {
+  if (!standard || typeof standard !== 'object') return ''
+  const text = standard.standard_text || standard.text || ''
+  if (!text) return ''
+  const id = standard.standard_id || standard.id
+  const cleanText = cleanDisplayText(text)
+  return id ? `[${id}] ${cleanText}` : cleanText
+}
+
+export function buildScaffoldingPresentation(rec, llmAnalysis = null) {
+  const sections = {
+    assessment: '',
+    gap: '',
+    standard: '',
+    confidence: '',
+  }
+
+  if (!rec || typeof rec !== 'object') return sections
+
+  const analysis = llmAnalysis || rec.llm_analysis || rec.analysis || {}
+  let current = 'assessment'
+
+  normalizeRationaleForParsing(rec.rationale).forEach((line) => {
+    const confidenceMatch = line.match(/^신뢰도\s*[:：]\s*(.*)$/)
+    if (confidenceMatch) {
+      sections.confidence = sections.confidence || formatConfidenceValue(confidenceMatch[1])
+      return
+    }
+
+    const assessmentMatch = line.match(/^(?:평가\s*요약|분석\s*요약)\s*[:：]\s*(.*)$/)
+    if (assessmentMatch) {
+      current = 'assessment'
+      sections.assessment = appendTextFragment(sections.assessment, assessmentMatch[1])
+      return
+    }
+
+    const gapMatch = line.match(/^주요\s*학습\s*격차\s*[:：]\s*(.*)$/)
+    if (gapMatch) {
+      current = 'gap'
+      sections.gap = appendTextFragment(sections.gap, gapMatch[1])
+      return
+    }
+
+    const standardMatch = line.match(/^(?:관련|근거)\s*성취기준\s*[:：]\s*(.*)$/)
+    if (standardMatch) {
+      current = 'standard'
+      sections.standard = appendTextFragment(sections.standard, standardMatch[1])
+      return
+    }
+
+    if (/^[상중하]\s*[:：]/.test(line)) {
+      sections.assessment = appendTextFragment(sections.assessment, line.replace(/^[상중하]\s*[:：]\s*/, ''))
+      return
+    }
+
+    sections[current] = appendTextFragment(sections[current], line)
+  })
+
+  if (!sections.assessment && typeof analysis.analysis_summary === 'string') {
+    sections.assessment = cleanDisplayText(analysis.analysis_summary)
+  }
+  if (!sections.gap) sections.gap = getLearningGapText(analysis, rec)
+  const standardDisplay = getStandardDisplayText(rec.achievement_standard)
+  if (standardDisplay) {
+    sections.standard = standardDisplay
+  } else {
+    sections.standard = cleanDisplayText(sections.standard)
+  }
+  sections.assessment = cleanDisplayText(sections.assessment)
+  sections.gap = cleanDisplayText(sections.gap)
+
+  const directConfidence =
+    rec.confidence_score ??
+    rec.confidence ??
+    analysis.confidence_score ??
+    analysis.confidence
+  sections.confidence =
+    sections.confidence ||
+    formatConfidenceValue(directConfidence) ||
+    extractConfidenceFromText(rec.rationale)
+
+  return sections
+}
+
 function normalizeScaffoldingDetailsBlock(details) {
   if (!details || typeof details !== 'object') return details
   const next = { ...details }
   if (next.level != null) next.level = mapLevelToKorean(next.level) ?? next.level
-  if (typeof next.description === 'string') next.description = mapLevelTokensInString(next.description)
+  if (typeof next.description === 'string') next.description = cleanDisplayText(next.description)
   if (Array.isArray(next.strategies)) {
-    next.strategies = next.strategies.map((s) => (typeof s === 'string' ? mapLevelTokensInString(s) : s))
+    next.strategies = next.strategies.map((s) => (typeof s === 'string' ? cleanDisplayText(s) : s))
   }
   if (Array.isArray(next.activities)) {
     next.activities = next.activities.map((a) => {
       if (!a || typeof a !== 'object') return a
       const act = { ...a }
-      if (typeof act.name === 'string') act.name = mapLevelTokensInString(act.name)
-      if (typeof act.description === 'string') act.description = mapLevelTokensInString(act.description)
+      if (typeof act.name === 'string') act.name = cleanDisplayText(act.name)
+      if (typeof act.description === 'string') act.description = cleanDisplayText(act.description)
       return act
     })
   }
@@ -52,45 +194,46 @@ function pickAchievementStandardForScaffolding(ach) {
   return Object.keys(out).length ? out : ach
 }
 
-function normalizeScaffoldingRecommendations(rec) {
+function normalizeScaffoldingRecommendations(rec, llmAnalysis = null) {
   if (rec == null) return rec
   if (typeof rec === 'string') return mapLevelTokensInString(rec)
   const next = { ...rec }
   if (next.recommended_level != null) next.recommended_level = mapLevelToKorean(next.recommended_level) ?? next.recommended_level
-  if (typeof next.rationale === 'string') next.rationale = mapLevelTokensInString(next.rationale)
-  if (typeof next.additional_notes === 'string') next.additional_notes = mapLevelTokensInString(next.additional_notes)
+  if (typeof next.rationale === 'string') next.rationale = cleanDisplayText(next.rationale)
+  if (typeof next.additional_notes === 'string') next.additional_notes = cleanDisplayText(next.additional_notes)
   if (next.scaffolding_details) next.scaffolding_details = normalizeScaffoldingDetailsBlock(next.scaffolding_details)
   if (next.achievement_standard) {
     next.achievement_standard = pickAchievementStandardForScaffolding({ ...next.achievement_standard })
   }
+  next.presentation = buildScaffoldingPresentation(next, llmAnalysis)
   return next
 }
 
 function normalizeFeedbackItem(fb) {
   if (!fb || typeof fb !== 'object') return fb
   const next = { ...fb }
-  if (typeof next.performance === 'string') next.performance = mapLevelTokensInString(next.performance)
+  if (typeof next.performance === 'string') next.performance = cleanDisplayText(next.performance)
   if (next.llm_analysis && typeof next.llm_analysis === 'object') {
     next.llm_analysis = { ...next.llm_analysis }
     if (next.llm_analysis.detected_level != null) {
       next.llm_analysis.detected_level = mapLevelToKorean(next.llm_analysis.detected_level) ?? next.llm_analysis.detected_level
     }
     if (typeof next.llm_analysis.analysis_summary === 'string') {
-      next.llm_analysis.analysis_summary = mapLevelTokensInString(next.llm_analysis.analysis_summary)
+      next.llm_analysis.analysis_summary = cleanDisplayText(next.llm_analysis.analysis_summary)
     }
     if (Array.isArray(next.llm_analysis.learning_gaps)) {
       next.llm_analysis.learning_gaps = next.llm_analysis.learning_gaps.map((g) =>
-        typeof g === 'string' ? mapLevelTokensInString(g) : g,
+        typeof g === 'string' ? cleanDisplayText(g) : g,
       )
     }
     if (Array.isArray(next.llm_analysis.recommended_strategies)) {
       next.llm_analysis.recommended_strategies = next.llm_analysis.recommended_strategies.map((s) =>
-        typeof s === 'string' ? mapLevelTokensInString(s) : s,
+        typeof s === 'string' ? cleanDisplayText(s) : s,
       )
     }
   }
   if (next.scaffolding_recommendations != null) {
-    next.scaffolding_recommendations = normalizeScaffoldingRecommendations(next.scaffolding_recommendations)
+    next.scaffolding_recommendations = normalizeScaffoldingRecommendations(next.scaffolding_recommendations, next.llm_analysis)
   }
   return next
 }
@@ -111,17 +254,18 @@ function normalizeScaffoldingApiResponse(data) {
   if (!data || typeof data !== 'object') return data
   const next = { ...data }
   if (next.recommended_level != null) next.recommended_level = mapLevelToKorean(next.recommended_level) ?? next.recommended_level
-  if (typeof next.rationale === 'string') next.rationale = mapLevelTokensInString(next.rationale)
+  if (typeof next.rationale === 'string') next.rationale = cleanDisplayText(next.rationale)
   if (next.scaffolding_details) next.scaffolding_details = normalizeScaffoldingDetailsBlock(next.scaffolding_details)
   if (next.achievement_standard) {
     next.achievement_standard = pickAchievementStandardForScaffolding({ ...next.achievement_standard })
   }
   if (Array.isArray(next.related_achievement_standards)) {
     next.related_achievement_standards = next.related_achievement_standards.map((item) =>
-      typeof item === 'string' ? mapLevelTokensInString(item) : item,
+      typeof item === 'string' ? cleanDisplayText(item) : item,
     )
   }
-  if (typeof next.additional_notes === 'string') next.additional_notes = mapLevelTokensInString(next.additional_notes)
+  if (typeof next.additional_notes === 'string') next.additional_notes = cleanDisplayText(next.additional_notes)
+  next.presentation = buildScaffoldingPresentation(next, next.llm_analysis)
   return next
 }
 

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -153,6 +153,7 @@ h3 {
   flex: 0 0 auto;
   align-items: center;
   gap: 10px;
+  margin: 0 0 0 auto;
 }
 
 .global-search {
@@ -184,7 +185,6 @@ h3 {
 }
 
 .mode-button,
-.primary-action,
 .ghost-button {
   display: inline-flex;
   height: 42px;
@@ -203,11 +203,14 @@ h3 {
   color: var(--purple);
 }
 
-.mode-button.is-active,
-.primary-action {
+.mode-button.is-active {
   border: 1px solid var(--purple);
   background: var(--purple);
   color: var(--white);
+}
+
+.mobile-role-switch {
+  display: none;
 }
 
 .theme-parent .mode-button {
@@ -215,8 +218,7 @@ h3 {
   color: var(--emerald);
 }
 
-.theme-parent .mode-button.is-active,
-.theme-parent .primary-action {
+.theme-parent .mode-button.is-active {
   border-color: var(--emerald);
   background: var(--emerald);
   color: var(--white);
@@ -265,44 +267,6 @@ h3 {
 .rail-item svg {
   width: 15px;
   height: 15px;
-}
-
-.rail-item span {
-  position: absolute;
-  top: 50%;
-  left: calc(100% + 10px);
-  z-index: 30;
-  display: inline-flex;
-  width: max-content;
-  min-width: 40px;
-  max-width: 72px;
-  height: 28px;
-  align-items: center;
-  justify-content: center;
-  border-radius: 5px;
-  background: #101010;
-  box-shadow:
-    rgba(50, 50, 93, 0.25) 0 14px 24px -14px,
-    rgba(0, 0, 0, 0.18) 0 8px 16px -12px;
-  color: var(--white);
-  font-size: 12px;
-  font-weight: 600;
-  line-height: 1;
-  opacity: 0;
-  padding: 0 10px;
-  pointer-events: none;
-  text-align: center;
-  transform: translate(4px, -50%);
-  transition:
-    opacity 0.16s ease,
-    transform 0.16s ease;
-  white-space: nowrap;
-}
-
-.rail-item:hover span,
-.rail-item:focus-visible span {
-  opacity: 1;
-  transform: translate(0, -50%);
 }
 
 .rail-item.is-active {
@@ -829,6 +793,83 @@ button.career-result {
   line-height: 18px;
 }
 
+.selected-standard-card {
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--surface);
+  padding: 14px 16px;
+}
+
+.selected-standard-card h3 {
+  margin-top: 12px;
+  color: var(--label);
+  font-size: 12px;
+  font-weight: 600;
+  line-height: 16px;
+}
+
+.selected-standard-card h3:first-child {
+  margin-top: 0;
+}
+
+.selected-standard-card p {
+  margin-top: 8px;
+  color: var(--body);
+  font-size: 12px;
+  line-height: 1.75;
+  word-break: keep-all;
+  overflow-wrap: break-word;
+}
+
+.selected-standard-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.selected-standard-meta span {
+  display: inline-flex;
+  min-height: 24px;
+  align-items: center;
+  border: 1px solid var(--purple-border);
+  border-radius: 4px;
+  background: var(--purple-soft);
+  color: var(--purple);
+  padding: 0 8px;
+  font-size: 10px;
+  font-weight: 600;
+  line-height: 14px;
+}
+
+.clean-dot-list {
+  display: grid;
+  gap: 9px;
+  margin: 10px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.clean-dot-list li {
+  position: relative;
+  padding-left: 14px;
+  color: var(--body);
+  font-size: 12px;
+  line-height: 1.65;
+  word-break: keep-all;
+  overflow-wrap: break-word;
+}
+
+.clean-dot-list li::before {
+  position: absolute;
+  top: 0.72em;
+  left: 0;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: var(--purple);
+  content: '';
+}
+
 .progress-track {
   height: 6px;
   overflow: hidden;
@@ -938,6 +979,72 @@ button.career-result {
   overflow-wrap: break-word;
 }
 
+.compact-list {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.compact-list li {
+  position: relative;
+  padding-left: 13px;
+  color: var(--body);
+  font-size: 12px;
+  line-height: 1.55;
+  word-break: keep-all;
+  overflow-wrap: break-word;
+}
+
+.compact-list li::before {
+  position: absolute;
+  top: 0.68em;
+  left: 0;
+  width: 4px;
+  height: 4px;
+  border-radius: 50%;
+  background: currentColor;
+  content: '';
+  opacity: 0.55;
+}
+
+.result-compact-list {
+  margin-top: 10px;
+}
+
+.result-compact-list li {
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 13px;
+  line-height: 1.7;
+}
+
+.inline-more-button {
+  display: inline-flex;
+  min-height: 30px;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--purple-border);
+  border-radius: 4px;
+  background: var(--white);
+  color: var(--purple);
+  padding: 0 10px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.theme-parent .inline-more-button {
+  border-color: var(--emerald-border);
+  color: var(--emerald);
+}
+
+.result-more-button {
+  margin-top: 12px;
+  border-color: rgba(255, 255, 255, 0.22);
+  background: rgba(255, 255, 255, 0.09);
+  color: rgba(255, 255, 255, 0.9);
+}
+
 .strategy-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -1015,7 +1122,7 @@ button.career-result {
   display: grid;
   grid-template-columns: 84px minmax(0, 1fr) 44px;
   gap: 14px;
-  align-items: center;
+  align-items: start;
 }
 
 .evidence-primary {
@@ -1101,7 +1208,9 @@ button.career-result {
   display: block;
   color: var(--navy);
   font-size: 13px;
-  line-height: 16px;
+  line-height: 1.55;
+  word-break: keep-all;
+  overflow-wrap: break-word;
 }
 
 .evidence-result strong {
@@ -1285,16 +1394,44 @@ button.career-result {
 }
 
 .parent-path-stage {
-  grid-template-columns: 24px 48px minmax(0, 1fr);
-  align-items: center;
+  grid-template-columns: 24px 92px minmax(0, 1fr);
+  align-items: start;
   border-left: 0;
+  column-gap: 12px;
+  row-gap: 4px;
   padding: 0;
 }
 
 .parent-path-stage .step-dot {
+  grid-row: 1 / span 2;
+  margin-top: 1px;
   width: 22px;
   height: 22px;
   font-size: 10px;
+}
+
+.parent-path-stage strong {
+  grid-row: 1 / span 2;
+  align-self: start;
+  line-height: 22px;
+  white-space: nowrap;
+}
+
+.parent-path-stage .path-stage-focus {
+  grid-column: 3;
+  grid-row: 1;
+  line-height: 18px;
+}
+
+.parent-path-stage .path-stage-description {
+  grid-column: 3;
+  grid-row: 2;
+  line-height: 18px;
+}
+
+.parent-path-stage .path-stage-description.is-alone {
+  grid-row: 1 / span 2;
+  align-self: center;
 }
 
 .empty-state {
@@ -1323,6 +1460,37 @@ button.career-result {
   line-height: 18px;
 }
 
+.status-banner {
+  border: 1px solid var(--purple-border);
+  border-radius: 6px;
+  background: var(--purple-soft);
+  padding: 12px 14px;
+}
+
+.status-banner strong {
+  display: block;
+  color: var(--purple);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 18px;
+}
+
+.status-banner p {
+  margin-top: 4px;
+  color: var(--label);
+  font-size: 11px;
+  line-height: 17px;
+}
+
+.status-banner.error {
+  border-color: #ffd7ef;
+  background: #fff5fb;
+}
+
+.status-banner.error strong {
+  color: var(--ruby);
+}
+
 .mobile-only {
   display: none;
 }
@@ -1333,13 +1501,14 @@ button.career-result {
   }
 
   .topbar {
-    position: static;
+    position: relative;
     min-height: 88px;
     padding: 18px 20px 14px;
   }
 
   .brand-lockup {
     gap: 14px;
+    padding-right: 92px;
   }
 
   .brand-mark {
@@ -1358,7 +1527,7 @@ button.career-result {
   }
 
   .topbar-actions {
-    gap: 8px;
+    display: none;
   }
 
   .global-search,
@@ -1366,9 +1535,28 @@ button.career-result {
     display: none;
   }
 
-  .primary-action {
+  .mobile-role-switch {
+    position: absolute;
+    top: 16px;
+    right: 20px;
+    display: inline-flex;
     height: 34px;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--purple-border);
+    border-radius: 4px;
+    background: var(--white);
     padding: 0 14px;
+    color: var(--purple);
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+    box-shadow: var(--shadow-1);
+  }
+
+  .theme-parent .mobile-role-switch {
+    border-color: var(--emerald-border);
+    color: var(--emerald);
   }
 
   .workspace {
@@ -1484,7 +1672,7 @@ button.career-result {
   }
 
   .parent-path-stage {
-    grid-template-columns: 22px 44px minmax(0, 1fr);
+    grid-template-columns: 22px 92px minmax(0, 1fr);
     gap: 12px;
   }
 

--- a/client/src/views/parent/ParentCareerPage.vue
+++ b/client/src/views/parent/ParentCareerPage.vue
@@ -96,8 +96,8 @@
           >
             <span class="step-dot">{{ index + 1 }}</span>
             <strong>{{ stage.stage }}</strong>
-            <p v-if="stage.focus">{{ stage.focus }}</p>
-            <p>{{ stage.description }}</p>
+            <p v-if="stage.focus" class="path-stage-focus">{{ stage.focus }}</p>
+            <p :class="['path-stage-description', !stage.focus && 'is-alone']">{{ stage.description }}</p>
           </div>
         </div>
         <div v-else class="empty-state spaced">
@@ -110,18 +110,21 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { HeartHandshake } from 'lucide-vue-next'
 import { getCareerRecommendation, searchCareer } from '../../api'
 import { useStudentStore } from '../../composables/useStudentStore'
 
 const { state: studentStore } = useStudentStore()
+const route = useRoute()
 
 const loading = ref(false)
 const currentSkills = ref('손작업과 순서 기억이 안정적이고, 그림 자료를 보면 활동을 오래 지속합니다.')
 const interests = ref('요리, 만들기, 정리')
 const careerRecommendation = ref(null)
 const searchResults = ref([])
+const routeSearchQuery = computed(() => (typeof route.query.q === 'string' ? route.query.q.trim() : ''))
 
 const recommendedCareers = computed(() =>
   careerRecommendation.value?.recommended_careers?.length
@@ -167,8 +170,20 @@ async function recommendCareer() {
   }
 }
 
-onMounted(async () => {
+async function refreshCareerSearch() {
   const response = await searchCareer(currentSkills.value, { current_skills: currentSkills.value, k: 3 })
   searchResults.value = response.results || []
+}
+
+watch(routeSearchQuery, async (query) => {
+  if (!query || query === currentSkills.value) return
+  currentSkills.value = query
+  await refreshCareerSearch()
+  await recommendCareer()
+})
+
+onMounted(async () => {
+  if (routeSearchQuery.value) currentSkills.value = routeSearchQuery.value
+  await refreshCareerSearch()
 })
 </script>

--- a/client/src/views/teacher/TeacherCareerPage.vue
+++ b/client/src/views/teacher/TeacherCareerPage.vue
@@ -62,6 +62,16 @@
           <span v-if="recommendedCareers.length" class="badge soft">{{ recommendedCareers.length }}건</span>
         </div>
 
+        <div v-if="loading" class="status-banner spaced-sm">
+          <strong>새 진로 추천을 생성 중입니다.</strong>
+          <p>입력한 역량을 바탕으로 직업, 역량 격차, 단계별 경로를 다시 정리하고 있습니다.</p>
+        </div>
+
+        <div v-if="errorMessage" class="status-banner error spaced-sm">
+          <strong>진로 추천을 불러오지 못했습니다.</strong>
+          <p>{{ errorMessage }}</p>
+        </div>
+
         <div v-if="loading && !recommendedCareers.length" class="empty-state spaced">
           <strong>진로 추천을 불러오는 중입니다.</strong>
         </div>
@@ -162,17 +172,21 @@
 
 <script setup>
 import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { Sparkles } from 'lucide-vue-next'
 import { getCareerRecommendation } from '../../api'
 import { useStudentStore } from '../../composables/useStudentStore'
 
 const { state: studentStore } = useStudentStore()
+const route = useRoute()
 
 const currentSkills = ref('손작업과 순서 기억이 안정적이며, 시각 자료를 활용한 활동에 오래 참여합니다.')
 const interestText = ref('그림 카드, 요리 활동, 반복 루틴')
 const careerRecommendation = ref(null)
 const selectedIndex = ref(0)
 const loading = ref(false)
+const errorMessage = ref('')
+const routeSearchQuery = computed(() => (typeof route.query.q === 'string' ? route.query.q.trim() : ''))
 
 const profileRows = computed(() => [
   { label: '현재 수준', value: studentStore.student?.current_level || '입력 대기' },
@@ -220,6 +234,7 @@ function percentText(score) {
 
 async function createRecommendation() {
   loading.value = true
+  errorMessage.value = ''
   try {
     careerRecommendation.value = await getCareerRecommendation({
       current_skills: currentSkills.value,
@@ -228,6 +243,9 @@ async function createRecommendation() {
       interests: interestText.value.split(',').map((item) => item.trim()).filter(Boolean),
     })
     selectedIndex.value = 0
+  } catch (error) {
+    errorMessage.value = '잠시 후 다시 시도해 주세요. 서버 연결 또는 AI 응답 시간이 길어졌을 수 있습니다.'
+    console.error(error)
   } finally {
     loading.value = false
   }
@@ -237,5 +255,14 @@ watch(recommendedCareers, (list) => {
   if (selectedIndex.value >= list.length) selectedIndex.value = 0
 })
 
-onMounted(createRecommendation)
+watch(routeSearchQuery, async (query) => {
+  if (!query || query === currentSkills.value) return
+  currentSkills.value = query
+  await createRecommendation()
+})
+
+onMounted(async () => {
+  if (routeSearchQuery.value) currentSkills.value = routeSearchQuery.value
+  await createRecommendation()
+})
 </script>

--- a/client/src/views/teacher/TeacherCurriculumPage.vue
+++ b/client/src/views/teacher/TeacherCurriculumPage.vue
@@ -4,9 +4,9 @@
       <section class="panel">
         <div class="panel-header">
           <div>
-            <p class="eyebrow">Search Filters</p>
+            <p class="eyebrow">기준 찾기</p>
             <h2 class="panel-title">성취기준 검색</h2>
-            <p class="panel-subtitle">수학과 국어 기준을 같은 형식으로 검색합니다.</p>
+            <p class="panel-subtitle">관찰 문장이나 수업 키워드를 입력해 오늘 수업과 가까운 기준을 찾습니다.</p>
           </div>
           <div class="panel-icon">
             <SlidersHorizontal />
@@ -44,10 +44,10 @@
       </section>
 
       <section class="panel dark">
-        <p class="eyebrow">What Matters</p>
-        <h2 class="panel-title">교사용 화면에 남긴 기능</h2>
+        <p class="eyebrow">수업 연결</p>
+        <h2 class="panel-title">기준을 목표로 좁히기</h2>
         <p class="panel-subtitle">
-          기준 원문, 과목/학년, 관련도, 선택 기준만 보여주고 벡터스토어 내부 정보는 숨겼습니다.
+          찾은 기준을 그대로 쓰기보다 학생이 오늘 보일 수 있는 행동으로 작게 나누어 활용합니다.
         </p>
       </section>
     </aside>
@@ -56,11 +56,10 @@
       <section class="panel elevated">
         <div class="panel-header">
           <div>
-            <p class="eyebrow">Curriculum Results</p>
+            <p class="eyebrow">찾은 성취기준</p>
             <h2 class="panel-title">검색 결과 {{ results.length }}개</h2>
-            <p class="panel-subtitle">결과를 선택하면 오른쪽에서 수업 목표로 정리됩니다.</p>
+            <p class="panel-subtitle">가장 가까운 기준을 선택해 수업 목표와 관찰 포인트를 정리합니다.</p>
           </div>
-          <span class="badge primary">GET /rag/curriculum-search</span>
         </div>
 
         <div v-if="results.length" class="list-stack spaced">
@@ -73,7 +72,7 @@
           >
             <code>{{ standardCode(item, index) }}</code>
             <div>
-              <strong>{{ compactContent(item.content) }}</strong>
+              <strong>{{ standardText(item) }}</strong>
               <p>{{ subjectLabel(item.metadata?.subject) }} · {{ item.metadata?.grade || '학년 정보 없음' }}</p>
             </div>
             <span class="mono">{{ scoreText(item.score) }}</span>
@@ -91,8 +90,8 @@
       <section class="panel">
         <div class="panel-header">
           <div>
-            <p class="eyebrow">Selected Standard</p>
-            <h2 class="panel-title">선택 기준</h2>
+            <p class="eyebrow">기준 상세</p>
+            <h2 class="panel-title">선택한 기준</h2>
           </div>
           <div class="panel-icon">
             <BookOpenCheck />
@@ -100,9 +99,21 @@
         </div>
 
         <template v-if="selectedResult">
-          <div class="callout spaced">
-            <strong>{{ standardCode(selectedResult, selectedIndex) }}</strong>
-            <p>{{ selectedResult.content }}</p>
+          <div class="selected-standard-card spaced">
+            <div class="selected-standard-meta">
+              <span>{{ standardCode(selectedResult, selectedIndex) }}</span>
+              <span>{{ subjectLabel(selectedResult.metadata?.subject) }}</span>
+              <span>{{ selectedResult.metadata?.grade || '학년 정보 없음' }}</span>
+            </div>
+            <h3>성취기준</h3>
+            <p>{{ standardText(selectedResult) }}</p>
+          </div>
+
+          <div v-if="selectedFocusItems.length" class="selected-standard-card spaced-sm">
+            <h3>수업에서 확인할 행동</h3>
+            <ul class="clean-dot-list">
+              <li v-for="item in selectedFocusItems" :key="item">{{ item }}</li>
+            </ul>
           </div>
 
           <div class="mini-grid spaced">
@@ -121,16 +132,16 @@
 
         <div v-else class="empty-state spaced">
           <strong>선택 기준 없음</strong>
-          <p>검색 결과를 선택하면 이곳에 기준 원문과 메타정보가 표시됩니다.</p>
+          <p>검색 결과를 선택하면 기준 원문과 수업에서 볼 행동이 정리됩니다.</p>
         </div>
       </section>
 
       <section class="panel">
-        <p class="eyebrow">Classroom Use</p>
+        <p class="eyebrow">수업 메모</p>
         <h2 class="panel-title">수업 적용 메모</h2>
         <div class="list-stack spaced">
           <div v-for="memo in lessonMemos" :key="memo" class="mini-card">
-            <strong>적용 포인트</strong>
+            <strong>활용 방법</strong>
             <p>{{ memo }}</p>
           </div>
         </div>
@@ -140,12 +151,14 @@
 </template>
 
 <script setup>
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { BookOpenCheck, SlidersHorizontal } from 'lucide-vue-next'
 import { searchCurriculum } from '../../api'
 import { useStudentStore } from '../../composables/useStudentStore'
 
 const { state: studentStore } = useStudentStore()
+const route = useRoute()
 
 const loading = ref(false)
 const results = ref([])
@@ -158,15 +171,26 @@ const filters = reactive({
 })
 
 const selectedResult = computed(() => results.value[selectedIndex.value] || null)
+const routeSearchQuery = computed(() => (typeof route.query.q === 'string' ? route.query.q.trim() : ''))
 
 const lessonMemos = [
-  '기준 원문을 그대로 목표 문장에 쓰기보다 오늘 수업 행동으로 좁혀 사용합니다.',
-  '추천 결과와 맞지 않는 기준은 교사가 선택하지 않고 다시 검색합니다.',
-  '국어와 수학 기준은 같은 카드 구조로 보여 비교가 쉽도록 했습니다.',
+  '학생이 오늘 보일 수 있는 행동 하나를 골라 수업 목표로 사용합니다.',
+  '기준이 넓게 느껴지면 활동이나 관찰 포인트를 하나만 선택해 기록합니다.',
+  '추천 결과와 맞지 않으면 다른 기준을 선택하거나 검색어를 더 구체적으로 바꿉니다.',
 ]
 
-function compactContent(content = '') {
-  return content.length > 96 ? `${content.slice(0, 96)}...` : content
+const selectedFocusItems = computed(() => {
+  const content = selectedResult.value?.content || ''
+  return [
+    ...extractSectionItems(content, '학습 목표'),
+    ...extractSectionItems(content, '활동'),
+  ].slice(0, 4)
+})
+
+function standardText(item) {
+  const content = String(item?.content || '')
+  const match = content.match(/성취기준\s*:\s*(.+)/)
+  return (match?.[1] || content).trim()
 }
 
 function standardCode(item, index) {
@@ -181,6 +205,27 @@ function subjectLabel(subject) {
 function scoreText(score) {
   if (typeof score !== 'number') return '-'
   return score.toFixed(2)
+}
+
+function extractSectionItems(content, sectionTitle) {
+  const lines = String(content || '').split('\n')
+  const items = []
+  let inSection = false
+
+  for (const rawLine of lines) {
+    const line = rawLine.trim()
+    if (!line) continue
+    if (line.startsWith(`${sectionTitle}:`)) {
+      inSection = true
+      continue
+    }
+    if (inSection && /^[가-힣A-Za-z ]+:$/.test(line) && !line.startsWith('-')) break
+    if (inSection && line.startsWith('-')) {
+      items.push(line.replace(/^-\s*/, '').trim())
+    }
+  }
+
+  return items
 }
 
 async function runSearch() {
@@ -200,7 +245,14 @@ async function runSearch() {
 }
 
 onMounted(async () => {
+  if (routeSearchQuery.value) filters.query = routeSearchQuery.value
   filters.disability_type = studentStore.student?.disability_type || ''
+  await runSearch()
+})
+
+watch(routeSearchQuery, async (query) => {
+  if (!query || query === filters.query) return
+  filters.query = query
   await runSearch()
 })
 </script>

--- a/client/src/views/teacher/TeacherOverviewPage.vue
+++ b/client/src/views/teacher/TeacherOverviewPage.vue
@@ -137,7 +137,20 @@
                 </article>
                 <article v-if="rationaleSections.gap" class="result-report-block">
                   <span>주요 학습 격차</span>
-                  <p>{{ rationaleSections.gap }}</p>
+                  <template v-if="gapItems.length">
+                    <ul class="compact-list result-compact-list">
+                      <li v-for="item in visibleGapItems" :key="item">{{ item }}</li>
+                    </ul>
+                    <button
+                      v-if="gapItems.length > SUMMARY_LIMIT"
+                      type="button"
+                      class="inline-more-button result-more-button"
+                      @click="showAllGaps = !showAllGaps"
+                    >
+                      {{ showAllGaps ? '접기' : `+ ${gapItems.length - SUMMARY_LIMIT}개 더 보기` }}
+                    </button>
+                  </template>
+                  <p v-else>{{ rationaleSections.gap }}</p>
                 </article>
                 <article v-if="rationaleSections.standard" class="result-report-block result-report-block-wide">
                   <span>근거 성취기준</span>
@@ -173,7 +186,7 @@
         <template v-if="quickRecommendation">
           <div class="strategy-grid spaced gap-y-6">
             <article
-              v-for="activity in activities"
+              v-for="activity in visibleActivities"
               :key="activity.name || activity"
               class="strategy-card space-y-3 py-4 leading-relaxed"
             >
@@ -183,6 +196,14 @@
               </p>
             </article>
           </div>
+          <button
+            v-if="activities.length > SUMMARY_LIMIT"
+            type="button"
+            class="inline-more-button spaced-sm"
+            @click="showAllActivities = !showAllActivities"
+          >
+            {{ showAllActivities ? '추천 활동 접기' : `추천 활동 ${activities.length - SUMMARY_LIMIT}개 더 보기` }}
+          </button>
         </template>
 
         <div v-else class="empty-state spaced">
@@ -252,7 +273,12 @@ import { RouterLink } from 'vue-router'
 import {
   UserRoundCheck,
 } from 'lucide-vue-next'
-import { getScaffoldingRecommendation, getStudentProgress, mapLevelToKorean } from '../../api'
+import {
+  buildScaffoldingPresentation,
+  getScaffoldingRecommendation,
+  getStudentProgress,
+  mapLevelToKorean,
+} from '../../api'
 import { useStudentStore } from '../../composables/useStudentStore'
 
 const { state: studentStore } = useStudentStore()
@@ -263,6 +289,9 @@ const observationDraft = ref(
 const progress = ref({ feedbacks: [], progress_summary: '' })
 const quickRecommendation = ref(null)
 const loadingRecommendation = ref(false)
+const showAllGaps = ref(false)
+const showAllActivities = ref(false)
+const SUMMARY_LIMIT = 3
 
 const recommendationForm = reactive({
   grade: '초등학교 3학년',
@@ -322,6 +351,14 @@ const activities = computed(() =>
       ],
 )
 
+const gapItems = computed(() => splitDisplayItems(rationaleSections.value?.gap))
+const visibleGapItems = computed(() =>
+  showAllGaps.value ? gapItems.value : gapItems.value.slice(0, SUMMARY_LIMIT),
+)
+const visibleActivities = computed(() =>
+  showAllActivities.value ? activities.value : activities.value.slice(0, SUMMARY_LIMIT),
+)
+
 const standard = computed(() => quickRecommendation.value?.achievement_standard || null)
 
 const primaryMatchPercent = computed(() =>
@@ -330,6 +367,8 @@ const primaryMatchPercent = computed(() =>
 
 const recommendationConfidence = computed(() => {
   const rec = quickRecommendation.value
+  if (rec?.presentation?.confidence) return rec.presentation.confidence
+
   const direct =
     rec?.confidence_score ??
     rec?.confidence ??
@@ -344,17 +383,9 @@ const recommendationConfidence = computed(() => {
   return match?.[1] || ''
 })
 
-const displayRationale = computed(() => {
-  const raw = String(quickRecommendation.value?.rationale || '')
-  return raw
-    .split('\n')
-    .filter((line) => !/^신뢰도\s*[:：]/.test(line.trim()))
-    .join('\n')
-    .trim()
-})
-
 const rationaleSections = computed(() =>
-  parseRationaleSections(displayRationale.value, levelSemantics(quickRecommendation.value?.recommended_level)),
+  quickRecommendation.value?.presentation ||
+  buildScaffoldingPresentation(quickRecommendation.value, quickRecommendation.value?.llm_analysis),
 )
 
 const evidenceList = computed(() => {
@@ -418,46 +449,43 @@ function stripRelatedScoreText(text) {
   return String(text || '').replace(/\s*\(관련도\s*[0-9]+(?:\.[0-9]+)?\)\s*$/g, '').trim()
 }
 
-function parseRationaleSections(text, semanticText = '') {
-  const sections = {
-    assessment: '',
-    gap: '',
-    standard: '',
-  }
-  let current = 'assessment'
+function splitDisplayItems(text) {
+  const value = String(text || '')
+    .replace(/\r\n?/g, '\n')
+    .replace(/^\s*(?:[-*•·]|\d+[.)])\s*/gm, '|')
+    .replace(/\s+(?:[-*•·]|\d+[.)])\s+/g, '|')
+    .replace(/\s*([?!])\s*,+\s*/g, '$1|')
+    .replace(/([?!])\s+(?=[가-힣A-Za-z0-9])/g, '$1|')
+    .replace(/\s*\.\s*,+\s*/g, '.|')
+    .replace(/다\.\s+/g, '다.|')
+    .replace(/\.\s+(?=[가-힣A-Za-z0-9])/g, '.|')
+    .replace(/\s+·\s+/g, '|')
+    .replace(/\n+/g, '|')
+    .trim()
+  if (!value) return []
 
-  String(text || '')
-    .split('\n')
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .forEach((line) => {
-      if (semanticText && line === semanticText.trim()) return
-
-      const gapMatch = line.match(/^주요 학습 격차\s*[:：]\s*(.*)$/)
-      if (gapMatch) {
-        current = 'gap'
-        sections.gap = appendSentence(sections.gap, gapMatch[1])
-        return
-      }
-
-      const standardMatch = line.match(/^관련 성취기준\s*[:：]\s*(.*)$/)
-      if (standardMatch) {
-        current = 'standard'
-        sections.standard = appendSentence(sections.standard, standardMatch[1])
-        return
-      }
-
-      if (/^[상중하]\s*[:：]/.test(line)) return
-      sections[current] = appendSentence(sections[current], line)
-    })
-
-  return sections
+  const items = value.split('|').flatMap(splitCommaItems).map(cleanListItem).filter(Boolean)
+  return [...new Set(items)]
 }
 
-function appendSentence(base, next) {
-  const value = String(next || '').trim()
-  if (!value) return base
-  return base ? `${base} ${value}` : value
+function splitCommaItems(item) {
+  const value = cleanListItem(item)
+  if (!value) return []
+  const parts = value.split(/\s*,\s+/).map(cleanListItem).filter(Boolean)
+  if (parts.length > 1 && parts.every((part) => part.length >= 6)) return parts
+  return [value]
+}
+
+function cleanListItem(item) {
+  return String(item || '')
+    .trim()
+    .replace(/^(?:[-*•·]\s*|\d+[.)]\s*)+/, '')
+    .replace(/^['"“”‘’]+|['"“”‘’]+$/g, '')
+    .replace(/\s*([?!])\s*,+$/g, '$1')
+    .replace(/\s*\.\s*,+$/g, '.')
+    .replace(/[,;:\s]+$/g, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
 }
 
 function levelSemantics(level) {
@@ -485,6 +513,8 @@ function formatDate(value) {
 async function createQuickRecommendation() {
   loadingRecommendation.value = true
   try {
+    showAllGaps.value = false
+    showAllActivities.value = false
     quickRecommendation.value = await getScaffoldingRecommendation({
       grade: recommendationForm.grade,
       subject: recommendationForm.subject,

--- a/client/src/views/teacher/TeacherProgressPage.vue
+++ b/client/src/views/teacher/TeacherProgressPage.vue
@@ -37,14 +37,16 @@
           <div>
             <p class="eyebrow">Feedback Timeline</p>
             <h2 class="panel-title">피드백 기록</h2>
-            <p class="panel-subtitle">최근 기록을 선택하면 오른쪽에서 추천 원문을 확인합니다.</p>
+            <p class="panel-subtitle">
+              {{ searchQuery ? `'${searchQuery}' 검색 결과 ${visibleFeedbacks.length}개` : '최근 기록을 선택하면 오른쪽에서 추천 원문을 확인합니다.' }}
+            </p>
           </div>
           <button class="btn ghost" type="button" :disabled="loading" @click="loadProgress">새로고침</button>
         </div>
 
-        <div v-if="feedbacks.length" class="list-stack spaced">
+        <div v-if="visibleFeedbacks.length" class="list-stack spaced">
           <button
-            v-for="(feedback, index) in orderedFeedbacks"
+            v-for="(feedback, index) in visibleFeedbacks"
             :key="feedback.id || index"
             type="button"
             :class="['timeline-row', selectedId === feedback.id && 'is-selected']"
@@ -58,8 +60,8 @@
         </div>
 
         <div v-else class="empty-state spaced">
-          <strong>아직 저장된 피드백이 없습니다.</strong>
-          <p>추천 화면에서 AI 추천을 실행하면 이곳에 기록이 쌓입니다.</p>
+          <strong>{{ searchQuery ? '검색 결과가 없습니다.' : '아직 저장된 피드백이 없습니다.' }}</strong>
+          <p>{{ searchQuery ? '다른 날짜, 수준, 피드백 문장으로 다시 검색해보세요.' : '추천 화면에서 AI 추천을 실행하면 이곳에 기록이 쌓입니다.' }}</p>
         </div>
       </section>
     </main>
@@ -113,16 +115,29 @@
 </template>
 
 <script setup>
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
+import { useRoute } from 'vue-router'
 import { ClipboardList, TrendingUp } from 'lucide-vue-next'
 import { getStudentProgress, mapLevelToKorean } from '../../api'
 
 const loading = ref(false)
 const feedbacks = ref([])
 const selectedId = ref(null)
+const route = useRoute()
 
 const orderedFeedbacks = computed(() => [...feedbacks.value].reverse())
-const selectedFeedback = computed(() => feedbacks.value.find((feedback) => feedback.id === selectedId.value) || orderedFeedbacks.value[0] || null)
+const searchQuery = computed(() => (typeof route.query.q === 'string' ? route.query.q.trim() : ''))
+const visibleFeedbacks = computed(() => {
+  const q = searchQuery.value.toLowerCase()
+  if (!q) return orderedFeedbacks.value
+  return orderedFeedbacks.value.filter((feedback) => feedbackMatches(feedback, q))
+})
+const selectedFeedback = computed(() =>
+  feedbacks.value.find((feedback) => feedback.id === selectedId.value) ||
+  visibleFeedbacks.value[0] ||
+  orderedFeedbacks.value[0] ||
+  null,
+)
 const latestLevel = computed(() => selectedFeedback.value?.llm_analysis?.detected_level || '중')
 const progressSummary = computed(() => {
   const count = feedbacks.value.length
@@ -152,6 +167,21 @@ const recommendationText = computed(() => {
   return rec.rationale || rec.additional_notes || rec.scaffolding_details?.description || ''
 })
 
+function feedbackMatches(feedback, query) {
+  const fields = [
+    feedback.teacher_description,
+    feedback.performance,
+    feedback.scaffolding_effectiveness,
+    feedback.disability_type,
+    feedback.llm_analysis?.detected_level,
+    feedback.llm_analysis?.analysis_summary,
+    ...(feedback.llm_analysis?.learning_gaps || []),
+    feedback.scaffolding_recommendations?.rationale,
+    feedback.created_at,
+  ]
+  return fields.some((field) => String(field || '').toLowerCase().includes(query))
+}
+
 function levelLabel(level) {
   const mapped = mapLevelToKorean(level)
   return mapped != null && mapped !== '' ? mapped : '대기'
@@ -177,11 +207,15 @@ async function loadProgress() {
   try {
     const progress = await getStudentProgress()
     feedbacks.value = progress.feedbacks || []
-    selectedId.value = orderedFeedbacks.value[0]?.id || null
+    selectedId.value = visibleFeedbacks.value[0]?.id || orderedFeedbacks.value[0]?.id || null
   } finally {
     loading.value = false
   }
 }
+
+watch(searchQuery, () => {
+  selectedId.value = visibleFeedbacks.value[0]?.id || orderedFeedbacks.value[0]?.id || null
+})
 
 onMounted(loadProgress)
 </script>

--- a/client/src/views/teacher/TeacherScaffoldingPage.vue
+++ b/client/src/views/teacher/TeacherScaffoldingPage.vue
@@ -89,6 +89,9 @@
               <p class="result-kicker">감지된 지원 수준</p>
               <strong class="result-level-mark">{{ levelLabel(recommendation.recommended_level) }}</strong>
             </div>
+            <span v-if="detailConfidence" class="result-confidence">
+              신뢰도 {{ detailConfidence }}
+            </span>
           </div>
 
           <div class="result-report-grid">
@@ -99,7 +102,20 @@
             </article>
             <article v-if="detailRationaleSections.gap" class="result-report-block">
               <span>주요 학습 격차</span>
-              <p>{{ detailRationaleSections.gap }}</p>
+              <template v-if="gapItems.length">
+                <ul class="compact-list result-compact-list">
+                  <li v-for="item in visibleGapItems" :key="item">{{ item }}</li>
+                </ul>
+                <button
+                  v-if="gapItems.length > SUMMARY_LIMIT"
+                  type="button"
+                  class="inline-more-button result-more-button"
+                  @click="showAllGaps = !showAllGaps"
+                >
+                  {{ showAllGaps ? '접기' : `+ ${gapItems.length - SUMMARY_LIMIT}개 더 보기` }}
+                </button>
+              </template>
+              <p v-else>{{ detailRationaleSections.gap }}</p>
             </article>
             <article v-if="detailRationaleSections.standard" class="result-report-block result-report-block-wide">
               <span>근거 성취기준</span>
@@ -133,11 +149,19 @@
         </div>
 
         <div class="strategy-grid spaced">
-          <article v-for="activity in activities" :key="activity.name || activity" class="strategy-card">
+          <article v-for="activity in visibleActivities" :key="activity.name || activity" class="strategy-card">
             <strong>{{ activity.name || activity }}</strong>
             <p>{{ activity.description || '학생 반응에 따라 도움 강도를 조절하며 진행합니다.' }}</p>
           </article>
         </div>
+        <button
+          v-if="activities.length > SUMMARY_LIMIT"
+          type="button"
+          class="inline-more-button spaced-sm"
+          @click="showAllActivities = !showAllActivities"
+        >
+          {{ showAllActivities ? '추천 활동 접기' : `추천 활동 ${activities.length - SUMMARY_LIMIT}개 더 보기` }}
+        </button>
       </section>
     </main>
 
@@ -185,7 +209,12 @@
 <script setup>
 import { computed, onMounted, reactive, ref } from 'vue'
 import { UserRoundCog } from 'lucide-vue-next'
-import { getScaffoldingRecommendation, getStudentProgress, mapLevelToKorean } from '../../api'
+import {
+  buildScaffoldingPresentation,
+  getScaffoldingRecommendation,
+  getStudentProgress,
+  mapLevelToKorean,
+} from '../../api'
 import { useStudentStore } from '../../composables/useStudentStore'
 
 const { state: studentStore } = useStudentStore()
@@ -193,6 +222,9 @@ const { state: studentStore } = useStudentStore()
 const loading = ref(false)
 const recommendation = ref(null)
 const feedbacks = ref([])
+const showAllGaps = ref(false)
+const showAllActivities = ref(false)
+const SUMMARY_LIMIT = 3
 const form = reactive({
   grade: '초등학교 3학년',
   subject: '수학',
@@ -222,11 +254,21 @@ const activities = computed(() =>
       ],
 )
 
+const gapItems = computed(() => splitDisplayItems(detailRationaleSections.value?.gap))
+const visibleGapItems = computed(() =>
+  showAllGaps.value ? gapItems.value : gapItems.value.slice(0, SUMMARY_LIMIT),
+)
+const visibleActivities = computed(() =>
+  showAllActivities.value ? activities.value : activities.value.slice(0, SUMMARY_LIMIT),
+)
+
 const standard = computed(() => recommendation.value?.achievement_standard || null)
 const detailLevelSemantics = computed(() => levelSemantics(recommendation.value?.recommended_level))
 const detailRationaleSections = computed(() =>
-  parseRationaleSections(recommendation.value?.rationale, detailLevelSemantics.value),
+  recommendation.value?.presentation ||
+  buildScaffoldingPresentation(recommendation.value, recommendation.value?.llm_analysis),
 )
+const detailConfidence = computed(() => detailRationaleSections.value?.confidence || '')
 const relatedStandards = computed(() =>
   recommendation.value?.related_achievement_standards?.length
     ? recommendation.value.related_achievement_standards
@@ -250,46 +292,43 @@ function levelSemantics(level) {
   return '추천 수준에 따른 지원 강도입니다.'
 }
 
-function parseRationaleSections(text, semanticText = '') {
-  const sections = {
-    assessment: '',
-    gap: '',
-    standard: '',
-  }
-  let current = 'assessment'
+function splitDisplayItems(text) {
+  const value = String(text || '')
+    .replace(/\r\n?/g, '\n')
+    .replace(/^\s*(?:[-*•·]|\d+[.)])\s*/gm, '|')
+    .replace(/\s+(?:[-*•·]|\d+[.)])\s+/g, '|')
+    .replace(/\s*([?!])\s*,+\s*/g, '$1|')
+    .replace(/([?!])\s+(?=[가-힣A-Za-z0-9])/g, '$1|')
+    .replace(/\s*\.\s*,+\s*/g, '.|')
+    .replace(/다\.\s+/g, '다.|')
+    .replace(/\.\s+(?=[가-힣A-Za-z0-9])/g, '.|')
+    .replace(/\s+·\s+/g, '|')
+    .replace(/\n+/g, '|')
+    .trim()
+  if (!value) return []
 
-  String(text || '')
-    .split('\n')
-    .map((line) => line.trim())
-    .filter((line) => line && !/^신뢰도\s*[:：]/.test(line))
-    .forEach((line) => {
-      if (semanticText && line === semanticText.trim()) return
-
-      const gapMatch = line.match(/^주요 학습 격차\s*[:：]\s*(.*)$/)
-      if (gapMatch) {
-        current = 'gap'
-        sections.gap = appendSentence(sections.gap, gapMatch[1])
-        return
-      }
-
-      const standardMatch = line.match(/^관련 성취기준\s*[:：]\s*(.*)$/)
-      if (standardMatch) {
-        current = 'standard'
-        sections.standard = appendSentence(sections.standard, standardMatch[1])
-        return
-      }
-
-      if (/^[상중하]\s*[:：]/.test(line)) return
-      sections[current] = appendSentence(sections[current], line)
-    })
-
-  return sections
+  const items = value.split('|').flatMap(splitCommaItems).map(cleanListItem).filter(Boolean)
+  return [...new Set(items)]
 }
 
-function appendSentence(base, next) {
-  const value = String(next || '').trim()
-  if (!value) return base
-  return base ? `${base} ${value}` : value
+function splitCommaItems(item) {
+  const value = cleanListItem(item)
+  if (!value) return []
+  const parts = value.split(/\s*,\s+/).map(cleanListItem).filter(Boolean)
+  if (parts.length > 1 && parts.every((part) => part.length >= 6)) return parts
+  return [value]
+}
+
+function cleanListItem(item) {
+  return String(item || '')
+    .trim()
+    .replace(/^(?:[-*•·]\s*|\d+[.)]\s*)+/, '')
+    .replace(/^['"“”‘’]+|['"“”‘’]+$/g, '')
+    .replace(/\s*([?!])\s*,+$/g, '$1')
+    .replace(/\s*\.\s*,+$/g, '.')
+    .replace(/[,;:\s]+$/g, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
 }
 
 function formatDate(value) {
@@ -305,6 +344,8 @@ function resetDraft() {
 async function requestRecommendation() {
   loading.value = true
   try {
+    showAllGaps.value = false
+    showAllActivities.value = false
     recommendation.value = await getScaffoldingRecommendation({ ...form })
     const progressData = await getStudentProgress()
     feedbacks.value = progressData.feedbacks || []


### PR DESCRIPTION
## Summary

이번 PR에서는 `client` 폴더 기준으로 교사용/학부모용 프론트엔드 UI와 실제 API 연동 흐름을 전반적으로 다듬었습니다.

주요 변경 사항:
- 교사용/학부모용 대시보드 UI 정리
- 모바일 화면에서 교사용 <-> 학부모용 전환 UX 개선
- 추천/기준/기록/진로 화면의 텍스트 가독성 및 레이아웃 보정
- 실제 API 응답 형식에 맞춘 프론트 파싱 안정화
- 진로 추천 요청 시 로딩/오류 상태 안내 추가
- API 호출 대기 시간이 긴 상황을 고려한 타임아웃 조정

---

## Details

### 1. Dashboard / Layout
- 교사용 홈, 추천, 기준, 기록, 진로 탭 레이아웃 정리
- 학부모용 홈/상세 탭 레이아웃을 교사용과 유사한 구조로 통일
- 우측 상단의 불필요한 설명 박스 제거 후 전체 UI 폭 재정렬
- 모바일 화면에서도 주요 컴포넌트 배치가 자연스럽게 보이도록 조정

### 2. Mobile UX
- 모바일 화면에서 교사용/학부모용 전환 버튼을 더 자연스럽게 배치
- 모바일 교사용 화면에도 아이콘 및 상단 전환 UX 반영
- 학부모용 모바일 상세 화면들도 상단 탭 전환 흐름에 맞게 정리

### 3. Scaffolding / Recommendation UI
- 추천 수준과 전략 영역의 가독성 개선
- 어두운 메인 박스 내부 정보 구조 정리
- 추천 전략 카드에 `추천 전략 1~4` 제목 추가
- 불필요하게 반복되던 설명 문구 제거
- 긴 텍스트가 `...` 처리되거나 잘리는 문제 완화

### 4. Achievement / Curriculum UI
- 기준 탭의 기술적인 설명 문구를 서비스형 문구로 정리
- 커리큘럼 결과 카드에서 긴 텍스트가 생략되지 않도록 표시 방식 보정
- 오른쪽 선택 기준 영역의 긴 문장을 더 읽기 쉽게 정리

### 5. Career Recommendation UI
- 진로 탭에서 현재 역량 입력 후 결과 확인 흐름 개선
- 추천 직업 / 역량 격차 / 단계별 경로 영역의 카드 정렬 및 텍스트 가독성 개선
- 학부모용 진로 탭의 small path 영역 줄바꿈 오류 수정
- 추천 요청 중 사용자에게 상태가 보이도록 로딩 안내 추가

### 6. API Handling
- 실제 API 응답 기준으로 프론트 파싱 로직 보정
- 요청 시간이 긴 API를 고려해 클라이언트 timeout 상향
- 진로 추천 요청 실패 시 오류 상태가 화면에 드러나도록 처리
- 응답 대기 중 결과 영역에서 로딩 상태를 확인할 수 있도록 개선

---

## Changed Files

주요 수정 파일:
- `client/src/App.vue`
- `client/src/api/index.js`
- `client/src/style.css`
- `client/src/views/teacher/TeacherOverviewPage.vue`
- `client/src/views/teacher/TeacherScaffoldingPage.vue`
- `client/src/views/teacher/TeacherCurriculumPage.vue`
- `client/src/views/teacher/TeacherProgressPage.vue`
- `client/src/views/teacher/TeacherCareerPage.vue`
- `client/src/views/parent/ParentCareerPage.vue`
- `client/package-lock.json`

---

## Notes
- 이번 PR은 `client` 프론트엔드 수정입니다.
- mock api와 실제 api 간의 UI and Design 괴리감 수정에 중점을 두었습니다.