### PR TITLE
Frontend

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -49,7 +49,7 @@
         >
           <component :is="item.icon" />
         </RouterLink>
-        <div class="rail-avatar">{{ isTeacherRoute ? '지훈' : '지훈' }}</div>
+        <div class="rail-avatar" :title="studentDisplayName">{{ railAvatarLabel }}</div>
       </aside>
 
       <nav class="mobile-tabs" aria-label="모바일 탭">
@@ -122,6 +122,16 @@ const parentItems = [
 ]
 
 const navItems = computed(() => (isTeacherRoute.value ? teacherItems : parentItems))
+const studentDisplayName = computed(() => {
+  const name = studentStore.student?.name?.trim()
+  return name || '이지훈'
+})
+const railAvatarLabel = computed(() => {
+  const name = studentDisplayName.value.replace(/\s+/g, '')
+  if (!name) return '학생'
+  if (/^[A-Za-z]+$/.test(name)) return name.slice(0, 2).toUpperCase()
+  return name.slice(-2)
+})
 
 const headers = {
   '/teacher/overview': {

--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -5,6 +5,11 @@ const apiClient = axios.create({
   timeout: 180000,
 })
 
+const DEFAULT_CURRICULUM_SUBJECTS = [
+  { slug: 'math', label: '수학' },
+  { slug: 'korean', label: '국어' },
+]
+
 /** 서버 레벨 토큰 → UI용 한글 (상·중·하) */
 const LEVEL_EN_TO_KO = { high: '상', medium: '중', low: '하' }
 
@@ -201,6 +206,9 @@ function normalizeScaffoldingRecommendations(rec, llmAnalysis = null) {
   if (next.recommended_level != null) next.recommended_level = mapLevelToKorean(next.recommended_level) ?? next.recommended_level
   if (typeof next.rationale === 'string') next.rationale = cleanDisplayText(next.rationale)
   if (typeof next.additional_notes === 'string') next.additional_notes = cleanDisplayText(next.additional_notes)
+  if (Array.isArray(next.teaching_points)) {
+    next.teaching_points = next.teaching_points.map((s) => (typeof s === 'string' ? cleanDisplayText(s) : s))
+  }
   if (next.scaffolding_details) next.scaffolding_details = normalizeScaffoldingDetailsBlock(next.scaffolding_details)
   if (next.achievement_standard) {
     next.achievement_standard = pickAchievementStandardForScaffolding({ ...next.achievement_standard })
@@ -231,6 +239,11 @@ function normalizeFeedbackItem(fb) {
         typeof s === 'string' ? cleanDisplayText(s) : s,
       )
     }
+    if (Array.isArray(next.llm_analysis.teaching_points)) {
+      next.llm_analysis.teaching_points = next.llm_analysis.teaching_points.map((s) =>
+        typeof s === 'string' ? cleanDisplayText(s) : s,
+      )
+    }
   }
   if (next.scaffolding_recommendations != null) {
     next.scaffolding_recommendations = normalizeScaffoldingRecommendations(next.scaffolding_recommendations, next.llm_analysis)
@@ -255,6 +268,9 @@ function normalizeScaffoldingApiResponse(data) {
   const next = { ...data }
   if (next.recommended_level != null) next.recommended_level = mapLevelToKorean(next.recommended_level) ?? next.recommended_level
   if (typeof next.rationale === 'string') next.rationale = cleanDisplayText(next.rationale)
+  if (Array.isArray(next.teaching_points)) {
+    next.teaching_points = next.teaching_points.map((s) => (typeof s === 'string' ? cleanDisplayText(s) : s))
+  }
   if (next.scaffolding_details) next.scaffolding_details = normalizeScaffoldingDetailsBlock(next.scaffolding_details)
   if (next.achievement_standard) {
     next.achievement_standard = pickAchievementStandardForScaffolding({ ...next.achievement_standard })
@@ -539,6 +555,42 @@ function toCurriculumSubjectCode(subject) {
   return map[subject] || subject
 }
 
+function normalizeCurriculumSubjectOptions(payload) {
+  const rawSubjects = Array.isArray(payload)
+    ? payload
+    : Array.isArray(payload?.subjects)
+      ? payload.subjects
+      : []
+
+  const subjects = rawSubjects
+    .map((item) => {
+      if (typeof item === 'string') {
+        const value = item.trim()
+        return value ? { slug: value, label: value } : null
+      }
+      if (!item || typeof item !== 'object') return null
+      const slug = String(item.slug || item.subject || item.code || '').trim()
+      const label = String(item.label || item.name || slug).trim()
+      if (!slug || !label) return null
+      return { ...item, slug, label }
+    })
+    .filter(Boolean)
+
+  if (!subjects.length) {
+    return DEFAULT_CURRICULUM_SUBJECTS.map((subject) => ({ ...subject }))
+  }
+
+  const deduped = []
+  const seen = new Set()
+  subjects.forEach((subject) => {
+    const key = `${subject.slug}::${subject.label}`
+    if (seen.has(key)) return
+    seen.add(key)
+    deduped.push(subject)
+  })
+  return deduped
+}
+
 function toGradeCode(grade) {
   if (!grade) return grade
   const match = String(grade).match(/[1-6]/)
@@ -563,6 +615,13 @@ export function getStudentProgress() {
   }, normalizeProgressPayload(sampleProgress))
 }
 
+export async function deleteStudentFeedbacks({ feedback_ids = [], delete_all = false } = {}) {
+  const data = (await apiClient.delete('/student/feedbacks', {
+    data: { feedback_ids, delete_all },
+  })).data
+  return data
+}
+
 export function getSchoolLife() {
   return withFallback(async () => {
     const data = (await apiClient.get('/student/school-life')).data
@@ -575,6 +634,13 @@ export function getScaffoldingRecommendation(payload) {
     const data = (await apiClient.post('/rag/scaffolding-recommendation', payload)).data
     return normalizeScaffoldingApiResponse(data)
   }, sampleScaffolding)
+}
+
+export function getCurriculumSubjects() {
+  return withFallback(
+    async () => normalizeCurriculumSubjectOptions((await apiClient.get('/rag/curriculum-subjects')).data),
+    DEFAULT_CURRICULUM_SUBJECTS.map((subject) => ({ ...subject })),
+  )
 }
 
 export function searchCurriculum(query, params = {}) {

--- a/client/src/composables/useCurriculumSubjects.js
+++ b/client/src/composables/useCurriculumSubjects.js
@@ -1,0 +1,48 @@
+import { computed, reactive, readonly } from 'vue'
+import { getCurriculumSubjects } from '../api'
+
+const FALLBACK_SUBJECTS = [
+  { slug: 'math', label: '수학' },
+  { slug: 'korean', label: '국어' },
+]
+
+const state = reactive({
+  subjects: FALLBACK_SUBJECTS.map((subject) => ({ ...subject })),
+  loading: false,
+  loaded: false,
+  error: '',
+})
+
+async function loadCurriculumSubjects(force = false) {
+  if (state.loaded && !force) return state.subjects
+
+  state.loading = true
+  state.error = ''
+  try {
+    const subjects = await getCurriculumSubjects()
+    state.subjects = Array.isArray(subjects) && subjects.length
+      ? subjects
+      : FALLBACK_SUBJECTS.map((subject) => ({ ...subject }))
+    state.loaded = true
+    return state.subjects
+  } catch (error) {
+    state.error = '과목 목록을 불러오지 못했습니다.'
+    state.subjects = FALLBACK_SUBJECTS.map((subject) => ({ ...subject }))
+    console.error(error)
+    return state.subjects
+  } finally {
+    state.loading = false
+  }
+}
+
+export function useCurriculumSubjects() {
+  const subjectOptions = computed(() =>
+    state.subjects.length ? state.subjects : FALLBACK_SUBJECTS,
+  )
+
+  return {
+    state: readonly(state),
+    subjectOptions,
+    loadCurriculumSubjects,
+  }
+}

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -680,6 +680,17 @@ button.career-result {
   color: var(--purple);
 }
 
+.btn.danger {
+  border-color: #ffd7ef;
+  background: var(--white);
+  color: #c0184f;
+}
+
+.btn.danger:hover {
+  border-color: #ea2261;
+  background: rgba(234, 34, 97, 0.06);
+}
+
 .theme-parent .btn {
   border-color: var(--emerald);
   background: var(--emerald);
@@ -1246,6 +1257,148 @@ button.career-result {
   font-weight: 500;
 }
 
+.feedback-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.feedback-toolbar,
+.feedback-delete-panel {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--surface);
+  padding: 10px 12px;
+  color: var(--body);
+  font-size: 11px;
+}
+
+.feedback-delete-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+  border-color: var(--purple-border);
+  background:
+    linear-gradient(180deg, rgba(83, 58, 253, 0.06), rgba(83, 58, 253, 0.025)),
+    var(--white);
+  padding: 14px 16px;
+  box-shadow:
+    rgba(50, 50, 93, 0.16) 0 18px 32px -26px,
+    rgba(0, 0, 0, 0.08) 0 10px 24px -20px;
+}
+
+.feedback-delete-copy {
+  min-width: 0;
+}
+
+.feedback-delete-panel h3 {
+  color: var(--navy);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 20px;
+}
+
+.feedback-delete-panel p:not(.eyebrow) {
+  margin-top: 4px;
+  color: var(--body);
+  font-size: 12px;
+  line-height: 17px;
+  overflow: visible;
+  text-overflow: clip;
+  white-space: nowrap;
+}
+
+.feedback-delete-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 8px;
+  width: 100%;
+}
+
+.feedback-delete-actions .btn {
+  min-width: 82px;
+}
+
+.feedback-select-all,
+.feedback-row-check {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.feedback-select-all {
+  color: var(--label);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.feedback-select-all input,
+.feedback-row-check input {
+  width: 16px;
+  height: 16px;
+  accent-color: var(--purple);
+}
+
+.feedback-notice {
+  margin-top: 10px;
+  border: 1px solid var(--purple-border);
+  border-radius: 5px;
+  background: var(--purple-soft);
+  color: var(--purple);
+  padding: 9px 12px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.feedback-select-row {
+  grid-template-columns: minmax(0, 1fr);
+  gap: 10px;
+  padding: 10px 12px;
+}
+
+.feedback-select-row.is-delete-mode {
+  grid-template-columns: 22px minmax(0, 1fr);
+}
+
+.feedback-select-row.is-marked-delete {
+  border-color: var(--purple-border);
+  background: rgba(83, 58, 253, 0.08);
+}
+
+.feedback-row-check {
+  justify-content: center;
+}
+
+.feedback-row-content {
+  display: grid;
+  grid-template-columns: 64px minmax(0, 1fr) auto 32px;
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  text-align: left;
+}
+
+.feedback-row-content:focus-visible {
+  outline: 2px solid var(--purple);
+  outline-offset: 4px;
+  border-radius: 4px;
+}
+
+.feedback-more-row {
+  display: flex;
+  justify-content: center;
+  margin-top: 12px;
+}
+
 .feedback-card {
   display: flex;
   flex-direction: column;
@@ -1665,6 +1818,39 @@ button.career-result {
   .timeline-row,
   .career-result {
     grid-template-columns: 1fr;
+  }
+
+  .feedback-action-row,
+  .feedback-toolbar,
+  .feedback-delete-panel,
+  .feedback-delete-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .feedback-toolbar,
+  .feedback-delete-panel {
+    display: flex;
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .feedback-delete-actions,
+  .feedback-delete-actions .btn {
+    min-width: 0;
+  }
+
+  .feedback-select-row {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .feedback-select-row.is-delete-mode {
+    grid-template-columns: 22px minmax(0, 1fr);
+  }
+
+  .feedback-row-content {
+    grid-template-columns: 1fr;
+    gap: 6px;
   }
 
   .home-step {

--- a/client/src/views/parent/ParentCareerPage.vue
+++ b/client/src/views/parent/ParentCareerPage.vue
@@ -50,6 +50,11 @@
           <span class="badge primary">진로 힌트</span>
         </div>
 
+        <div v-if="loading" class="status-banner spaced-sm">
+          <strong>새 진로 힌트를 생성 중입니다.</strong>
+          <p>강점과 좋아하는 활동을 바탕으로 진로 후보와 대화 힌트를 정리하고 있습니다.</p>
+        </div>
+
         <div class="list-stack spaced">
           <article v-for="career in recommendedCareers" :key="career.job_title" class="career-result">
             <div>

--- a/client/src/views/teacher/TeacherCurriculumPage.vue
+++ b/client/src/views/teacher/TeacherCurriculumPage.vue
@@ -13,6 +13,11 @@
           </div>
         </div>
 
+        <div v-if="loading" class="status-banner spaced-sm">
+          <strong>관련 성취기준을 찾는 중입니다.</strong>
+          <p>입력한 키워드와 선택 과목을 바탕으로 가까운 기준을 다시 정리하고 있습니다.</p>
+        </div>
+
         <label class="spaced">
           <span class="section-label">검색어</span>
           <textarea v-model="filters.query" class="textarea-like spaced-sm" rows="4" />
@@ -23,8 +28,9 @@
             <span class="section-label">과목</span>
             <select v-model="filters.subject" class="input-like spaced-sm">
               <option value="">전체</option>
-              <option>수학</option>
-              <option>국어</option>
+              <option v-for="subject in subjectOptions" :key="subject.slug" :value="subject.label">
+                {{ subject.label }}
+              </option>
             </select>
           </label>
           <label>
@@ -155,9 +161,11 @@ import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { BookOpenCheck, SlidersHorizontal } from 'lucide-vue-next'
 import { searchCurriculum } from '../../api'
+import { useCurriculumSubjects } from '../../composables/useCurriculumSubjects'
 import { useStudentStore } from '../../composables/useStudentStore'
 
 const { state: studentStore } = useStudentStore()
+const { subjectOptions, loadCurriculumSubjects } = useCurriculumSubjects()
 const route = useRoute()
 
 const loading = ref(false)
@@ -168,6 +176,15 @@ const filters = reactive({
   subject: '수학',
   grade: '',
   disability_type: '',
+})
+
+const subjectLabelMap = computed(() => {
+  const entries = {}
+  subjectOptions.value.forEach((subject) => {
+    entries[subject.slug] = subject.label
+    entries[subject.label] = subject.label
+  })
+  return entries
 })
 
 const selectedResult = computed(() => results.value[selectedIndex.value] || null)
@@ -198,8 +215,7 @@ function standardCode(item, index) {
 }
 
 function subjectLabel(subject) {
-  const map = { math: '수학', korean: '국어' }
-  return map[subject] || subject || '과목 정보 없음'
+  return subjectLabelMap.value[subject] || subject || '과목 정보 없음'
 }
 
 function scoreText(score) {
@@ -245,6 +261,13 @@ async function runSearch() {
 }
 
 onMounted(async () => {
+  await loadCurriculumSubjects()
+  if (filters.subject) {
+    const isValid = subjectOptions.value.some(
+      (subject) => subject.label === filters.subject || subject.slug === filters.subject,
+    )
+    if (!isValid) filters.subject = ''
+  }
   if (routeSearchQuery.value) filters.query = routeSearchQuery.value
   filters.disability_type = studentStore.student?.disability_type || ''
   await runSearch()

--- a/client/src/views/teacher/TeacherOverviewPage.vue
+++ b/client/src/views/teacher/TeacherOverviewPage.vue
@@ -78,6 +78,11 @@
           <span class="badge primary">Live API</span>
         </div>
 
+        <div v-if="loadingRecommendation" class="status-banner spaced-sm">
+          <strong>새 스캐폴딩 추천을 생성 중입니다.</strong>
+          <p>학생 관찰 기록과 선택 과목을 바탕으로 지원 수준과 전략을 다시 정리하고 있습니다.</p>
+        </div>
+
         <textarea
           v-model="observationDraft"
           class="textarea-like spaced-sm"
@@ -93,8 +98,9 @@
           <label>
             <span class="section-label">과목</span>
             <select v-model="recommendationForm.subject" class="input-like spaced-sm">
-              <option>수학</option>
-              <option>국어</option>
+              <option v-for="subject in subjectOptions" :key="subject.slug" :value="subject.label">
+                {{ subject.label }}
+              </option>
             </select>
           </label>
         </div>
@@ -197,12 +203,12 @@
             </article>
           </div>
           <button
-            v-if="activities.length > SUMMARY_LIMIT"
+            v-if="activities.length > ACTIVITY_PREVIEW_LIMIT"
             type="button"
             class="inline-more-button spaced-sm"
             @click="showAllActivities = !showAllActivities"
           >
-            {{ showAllActivities ? '추천 활동 접기' : `추천 활동 ${activities.length - SUMMARY_LIMIT}개 더 보기` }}
+            {{ showAllActivities ? '추천 활동 접기' : `추천 활동 ${activities.length - ACTIVITY_PREVIEW_LIMIT}개 더 보기` }}
           </button>
         </template>
 
@@ -216,8 +222,8 @@
     <aside class="column-stack">
       <section class="panel dark">
         <p class="eyebrow">Today Priority</p>
-        <h2 class="panel-title">학생 맞춤 수업 포인트</h2>
-        <p class="panel-subtitle">학생의 개별 특성을 고려한 오늘 수업 전 체크리스트입니다.</p>
+        <h2 class="panel-title">오늘 수업 체크포인트</h2>
+        <p class="panel-subtitle">학생 정보와 최근 기록을 반영한 수업 전 확인 목록입니다.</p>
 
         <div class="list-stack spaced">
           <div v-for="item in priorityList" :key="item" class="dark-list-item">{{ item }}</div>
@@ -279,9 +285,11 @@ import {
   getStudentProgress,
   mapLevelToKorean,
 } from '../../api'
+import { useCurriculumSubjects } from '../../composables/useCurriculumSubjects'
 import { useStudentStore } from '../../composables/useStudentStore'
 
 const { state: studentStore } = useStudentStore()
+const { subjectOptions, loadCurriculumSubjects } = useCurriculumSubjects()
 
 const observationDraft = ref(
   '수학 활동에서 수 모형을 보여주면 문제 풀이를 시작하지만, 말로만 설명하면 첫 단계에서 멈추고 도움을 요청하지 못합니다.',
@@ -292,11 +300,20 @@ const loadingRecommendation = ref(false)
 const showAllGaps = ref(false)
 const showAllActivities = ref(false)
 const SUMMARY_LIMIT = 3
+const ACTIVITY_PREVIEW_LIMIT = 4
 
 const recommendationForm = reactive({
   grade: '초등학교 3학년',
   subject: '수학',
 })
+
+function ensureSelectedSubject(currentValue) {
+  if (!subjectOptions.value.length) return currentValue
+  const isValid = subjectOptions.value.some(
+    (subject) => subject.label === currentValue || subject.slug === currentValue,
+  )
+  return isValid ? currentValue : subjectOptions.value[0].label
+}
 
 const studentName = computed(() => studentStore.student?.name || '이지훈')
 
@@ -356,7 +373,7 @@ const visibleGapItems = computed(() =>
   showAllGaps.value ? gapItems.value : gapItems.value.slice(0, SUMMARY_LIMIT),
 )
 const visibleActivities = computed(() =>
-  showAllActivities.value ? activities.value : activities.value.slice(0, SUMMARY_LIMIT),
+  showAllActivities.value ? activities.value : activities.value.slice(0, ACTIVITY_PREVIEW_LIMIT),
 )
 
 const standard = computed(() => quickRecommendation.value?.achievement_standard || null)
@@ -426,12 +443,72 @@ const previewStrategies = [
   '도움 요청 문장 카드 제공',
 ]
 
-const priorityList = [
-  '1. ADHD 투약 여부 및 아침 컨디션 확인',
-  '2. 수업 시작 전 시각적 스케줄러 배치',
-  '3. 과제 전환 시 3분 전 예고제 실시',
-  '4. 지시는 한 문장·한 단계, 성공 시 즉각 구두 강화',
-]
+const priorityList = computed(() => {
+  const aiPoints = quickRecommendation.value?.teaching_points
+  if (Array.isArray(aiPoints) && aiPoints.length) {
+    return aiPoints.slice(0, 4).map((item, index) => `${index + 1}. ${item}`)
+  }
+
+  const student = studentStore.student || {}
+  const sourceText = [
+    observationDraft.value,
+    latestFeedback.value?.teacher_description,
+    latestFeedback.value?.performance,
+    student.disability_type,
+    student.additional_diagnoses,
+    student.behavioral_traits,
+  ]
+    .filter(Boolean)
+    .join(' ')
+    .toLowerCase()
+
+  const items = []
+  if (/adhd|주의|산만|전환/.test(sourceText)) {
+    items.push('주의가 분산되기 쉬운 단계는 시작 전 자리 환경과 시각 단서를 확인')
+  }
+  if (/시각|카드|아이콘|번호|그림|순서/.test(sourceText)) {
+    items.push('핵심 조작 순서는 번호 카드나 그림 단서로 먼저 제시')
+  }
+  if (/말|구두|지시|설명/.test(sourceText)) {
+    items.push('구두 지시는 한 문장·한 단계로 줄이고 같은 시각 단서를 함께 제공')
+  }
+  if (/도움|멈|요청/.test(sourceText)) {
+    items.push('멈춘 지점에서 사용할 도움 요청 신호를 수업 전에 확인')
+  }
+
+  strategies.value.slice(0, 2).forEach((strategy) => {
+    const item = shortenPriorityText(strategy)
+    if (item) items.push(item)
+  })
+
+  if (standard.value?.standard_id) {
+    items.push(`${standard.value.standard_id} 기준과 연결해 성공 조건을 관찰`)
+  }
+
+  const fallbackItems = [
+    '수업 시작 전 학생의 컨디션과 과제 지속 가능 시간을 확인',
+    '처음 과제는 짧게 제시하고 성공 직후 구체적으로 강화',
+    '도움 강도는 관찰 반응에 맞춰 한 단계씩 줄이기',
+    '다음 활동 전 전환 신호를 미리 안내',
+  ]
+
+  const unique = [...new Set(items.filter(Boolean))]
+  fallbackItems.forEach((item) => {
+    if (unique.length < 4 && !unique.includes(item)) unique.push(item)
+  })
+
+  return unique.slice(0, 4).map((item, index) => `${index + 1}. ${item}`)
+})
+
+function shortenPriorityText(text) {
+  const cleaned = String(text || '')
+    .replace(/^(?:적용 시 고려사항|교육과정 내용요소|교육과정 성취수준 요소)\s*[:：]\s*/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+  if (!cleaned) return ''
+  const firstSentence = cleaned.split(/[.!?。]/)[0]?.trim() || cleaned
+  return firstSentence.length > 58 ? `${firstSentence.slice(0, 58)}…` : firstSentence
+}
 
 function scoreToPercent(raw) {
   if (raw == null || raw === '') return '—'
@@ -529,6 +606,8 @@ async function createQuickRecommendation() {
 }
 
 onMounted(async () => {
+  await loadCurriculumSubjects()
+  recommendationForm.subject = ensureSelectedSubject(recommendationForm.subject)
   const progressData = await getStudentProgress()
   progress.value = progressData
 })

--- a/client/src/views/teacher/TeacherProgressPage.vue
+++ b/client/src/views/teacher/TeacherProgressPage.vue
@@ -38,26 +38,99 @@
             <p class="eyebrow">Feedback Timeline</p>
             <h2 class="panel-title">피드백 기록</h2>
             <p class="panel-subtitle">
-              {{ searchQuery ? `'${searchQuery}' 검색 결과 ${visibleFeedbacks.length}개` : '최근 기록을 선택하면 오른쪽에서 추천 원문을 확인합니다.' }}
+              {{ searchQuery ? `'${searchQuery}' 검색 결과 ${filteredFeedbacks.length}개` : '최근 기록을 선택하면 오른쪽에서 추천 원문을 확인합니다.' }}
             </p>
           </div>
-          <button class="btn ghost" type="button" :disabled="loading" @click="loadProgress">새로고침</button>
+          <div class="feedback-action-row">
+            <button class="btn ghost" type="button" :disabled="loading || deleting" @click="loadProgress">새로고침</button>
+            <button
+              :class="['btn ghost', deleteMode && 'danger']"
+              type="button"
+              :disabled="!feedbacks.length || deleting"
+              @click="toggleDeleteMode"
+            >
+              {{ deleteMode ? '취소' : '기록 지우기' }}
+            </button>
+          </div>
         </div>
 
-        <div v-if="visibleFeedbacks.length" class="list-stack spaced">
-          <button
-            v-for="(feedback, index) in visibleFeedbacks"
-            :key="feedback.id || index"
-            type="button"
-            :class="['timeline-row', selectedId === feedback.id && 'is-selected']"
-            @click="selectedId = feedback.id"
-          >
-            <small>{{ formatDate(feedback.created_at) }}</small>
-            <strong>{{ feedback.teacher_description || feedback.performance || '기록 내용 없음' }}</strong>
-            <span class="badge soft">{{ levelLabel(feedback.llm_analysis?.detected_level) }}</span>
-            <span class="mono">{{ feedback.id ? `#${feedback.id}` : '-' }}</span>
-          </button>
+        <div v-if="deleteMode && filteredFeedbacks.length" class="feedback-delete-panel spaced">
+          <div class="feedback-delete-copy">
+            <p class="eyebrow">Delete Feedback</p>
+            <h3>삭제할 기록 선택</h3>
+            <p :title="deleteModeSummary">{{ deleteModeSummary }}</p>
+          </div>
+          <div class="feedback-delete-actions">
+            <label class="feedback-select-all">
+              <input
+                type="checkbox"
+                :checked="areVisibleFeedbacksSelected"
+                :disabled="deleting"
+                @change="toggleVisibleFeedbacks($event.target.checked)"
+              >
+              <span>현재 목록 선택</span>
+            </label>
+            <button
+              class="btn ghost"
+              type="button"
+              :disabled="!selectedFeedbackIds.length || deleting"
+              @click="deleteSelectedFeedbacks"
+            >
+              선택 삭제
+            </button>
+            <button
+              class="btn ghost danger"
+              type="button"
+              :disabled="!feedbacks.length || deleting"
+              @click="deleteAllFeedbacks"
+            >
+              전체 지우기
+            </button>
+          </div>
         </div>
+
+        <p v-if="deleteNotice" class="feedback-notice">{{ deleteNotice }}</p>
+
+        <template v-if="visibleFeedbacks.length">
+          <div class="list-stack spaced">
+            <article
+              v-for="(feedback, index) in visibleFeedbacks"
+              :key="feedback.id || index"
+              :class="[
+                'timeline-row',
+                'feedback-select-row',
+                deleteMode && 'is-delete-mode',
+                deleteMode && selectedFeedbackIds.includes(feedback.id) && 'is-marked-delete',
+                selectedId === feedback.id && 'is-selected',
+              ]"
+            >
+              <label v-if="deleteMode" class="feedback-row-check" @click.stop>
+                <input
+                  type="checkbox"
+                  :checked="selectedFeedbackIds.includes(feedback.id)"
+                  :disabled="!feedback.id || deleting"
+                  @change="toggleFeedbackSelection(feedback.id, $event.target.checked)"
+                >
+              </label>
+              <button
+                type="button"
+                class="feedback-row-content"
+                @click="handleFeedbackRowClick(feedback)"
+              >
+                <small>{{ formatDate(feedback.created_at) }}</small>
+                <strong>{{ feedback.teacher_description || feedback.performance || '기록 내용 없음' }}</strong>
+                <span class="badge soft">{{ levelLabel(feedback.llm_analysis?.detected_level) }}</span>
+                <span class="mono">{{ feedback.id ? `#${feedback.id}` : '-' }}</span>
+              </button>
+            </article>
+          </div>
+
+          <div v-if="hiddenFeedbackCount" class="feedback-more-row">
+            <button class="btn ghost" type="button" @click="showAllFeedbacks = !showAllFeedbacks">
+              {{ showAllFeedbacks ? '접기' : `${hiddenFeedbackCount}개 더보기` }}
+            </button>
+          </div>
+        </template>
 
         <div v-else class="empty-state spaced">
           <strong>{{ searchQuery ? '검색 결과가 없습니다.' : '아직 저장된 피드백이 없습니다.' }}</strong>
@@ -118,19 +191,48 @@
 import { computed, onMounted, ref, watch } from 'vue'
 import { useRoute } from 'vue-router'
 import { ClipboardList, TrendingUp } from 'lucide-vue-next'
-import { getStudentProgress, mapLevelToKorean } from '../../api'
+import { deleteStudentFeedbacks, getStudentProgress, mapLevelToKorean } from '../../api'
 
+const FEEDBACK_PREVIEW_LIMIT = 7
 const loading = ref(false)
+const deleting = ref(false)
+const deleteMode = ref(false)
+const deleteNotice = ref('')
 const feedbacks = ref([])
 const selectedId = ref(null)
+const selectedFeedbackIds = ref([])
+const showAllFeedbacks = ref(false)
 const route = useRoute()
 
 const orderedFeedbacks = computed(() => [...feedbacks.value].reverse())
 const searchQuery = computed(() => (typeof route.query.q === 'string' ? route.query.q.trim() : ''))
-const visibleFeedbacks = computed(() => {
+const filteredFeedbacks = computed(() => {
   const q = searchQuery.value.toLowerCase()
   if (!q) return orderedFeedbacks.value
   return orderedFeedbacks.value.filter((feedback) => feedbackMatches(feedback, q))
+})
+const hiddenFeedbackCount = computed(() => Math.max(filteredFeedbacks.value.length - FEEDBACK_PREVIEW_LIMIT, 0))
+const visibleFeedbacks = computed(() =>
+  showAllFeedbacks.value ? filteredFeedbacks.value : filteredFeedbacks.value.slice(0, FEEDBACK_PREVIEW_LIMIT),
+)
+const visibleFeedbackIds = computed(() => visibleFeedbacks.value.map((feedback) => feedback.id).filter(Boolean))
+const areVisibleFeedbacksSelected = computed(() =>
+  visibleFeedbackIds.value.length > 0 &&
+  visibleFeedbackIds.value.every((id) => selectedFeedbackIds.value.includes(id)),
+)
+const selectionSummary = computed(() => {
+  if (selectedFeedbackIds.value.length) return `${selectedFeedbackIds.value.length}개 선택됨`
+  if (hiddenFeedbackCount.value && !showAllFeedbacks.value) {
+    return `최근 ${FEEDBACK_PREVIEW_LIMIT}개 표시 · ${hiddenFeedbackCount.value}개 숨김`
+  }
+  return `총 ${filteredFeedbacks.value.length}개 기록`
+})
+const deleteModeSummary = computed(() => {
+  if (selectedFeedbackIds.value.length) return `${selectedFeedbackIds.value.length}개 선택됨`
+  if (hiddenFeedbackCount.value && !showAllFeedbacks.value) {
+    return `최근 ${FEEDBACK_PREVIEW_LIMIT}개 표시 · 더보기로 추가 선택`
+  }
+  return '선택 삭제 또는 전체 지우기'
 })
 const selectedFeedback = computed(() =>
   feedbacks.value.find((feedback) => feedback.id === selectedId.value) ||
@@ -182,6 +284,37 @@ function feedbackMatches(feedback, query) {
   return fields.some((field) => String(field || '').toLowerCase().includes(query))
 }
 
+function toggleFeedbackSelection(feedbackId, checked) {
+  if (!feedbackId) return
+  const next = new Set(selectedFeedbackIds.value)
+  if (checked) next.add(feedbackId)
+  else next.delete(feedbackId)
+  selectedFeedbackIds.value = [...next]
+}
+
+function toggleVisibleFeedbacks(checked) {
+  const next = new Set(selectedFeedbackIds.value)
+  visibleFeedbackIds.value.forEach((id) => {
+    if (checked) next.add(id)
+    else next.delete(id)
+  })
+  selectedFeedbackIds.value = [...next]
+}
+
+function handleFeedbackRowClick(feedback) {
+  if (deleteMode.value) {
+    toggleFeedbackSelection(feedback.id, !selectedFeedbackIds.value.includes(feedback.id))
+    return
+  }
+  selectedId.value = feedback.id
+}
+
+function toggleDeleteMode() {
+  deleteMode.value = !deleteMode.value
+  deleteNotice.value = ''
+  if (!deleteMode.value) selectedFeedbackIds.value = []
+}
+
 function levelLabel(level) {
   const mapped = mapLevelToKorean(level)
   return mapped != null && mapped !== '' ? mapped : '대기'
@@ -205,15 +338,63 @@ function formatDateTime(value) {
 async function loadProgress() {
   loading.value = true
   try {
+    const previousSelectedId = selectedId.value
     const progress = await getStudentProgress()
     feedbacks.value = progress.feedbacks || []
-    selectedId.value = visibleFeedbacks.value[0]?.id || orderedFeedbacks.value[0]?.id || null
+    const validIds = new Set(feedbacks.value.map((feedback) => feedback.id).filter(Boolean))
+    selectedFeedbackIds.value = selectedFeedbackIds.value.filter((id) => validIds.has(id))
+    selectedId.value = validIds.has(previousSelectedId)
+      ? previousSelectedId
+      : visibleFeedbacks.value[0]?.id || orderedFeedbacks.value[0]?.id || null
   } finally {
     loading.value = false
   }
 }
 
+async function deleteSelectedFeedbacks() {
+  const ids = selectedFeedbackIds.value
+  if (!ids.length || deleting.value) return
+  if (!window.confirm(`${ids.length}개의 피드백 기록을 삭제할까요?`)) return
+
+  deleting.value = true
+  deleteNotice.value = ''
+  try {
+    const result = await deleteStudentFeedbacks({ feedback_ids: ids })
+    selectedFeedbackIds.value = []
+    deleteMode.value = false
+    deleteNotice.value = `${result.deleted_count}개의 기록을 삭제했습니다.`
+    await loadProgress()
+  } catch (error) {
+    deleteNotice.value = '삭제 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.'
+  } finally {
+    deleting.value = false
+  }
+}
+
+async function deleteAllFeedbacks() {
+  if (!feedbacks.value.length || deleting.value) return
+  if (!window.confirm('모든 피드백 기록을 삭제할까요? 이 작업은 되돌릴 수 없습니다.')) return
+
+  deleting.value = true
+  deleteNotice.value = ''
+  try {
+    const result = await deleteStudentFeedbacks({ delete_all: true })
+    selectedFeedbackIds.value = []
+    deleteMode.value = false
+    showAllFeedbacks.value = false
+    deleteNotice.value = `${result.deleted_count}개의 기록을 모두 삭제했습니다.`
+    await loadProgress()
+  } catch (error) {
+    deleteNotice.value = '전체 삭제 중 문제가 발생했습니다. 잠시 후 다시 시도해주세요.'
+  } finally {
+    deleting.value = false
+  }
+}
+
 watch(searchQuery, () => {
+  showAllFeedbacks.value = false
+  selectedFeedbackIds.value = []
+  deleteMode.value = false
   selectedId.value = visibleFeedbacks.value[0]?.id || orderedFeedbacks.value[0]?.id || null
 })
 

--- a/client/src/views/teacher/TeacherScaffoldingPage.vue
+++ b/client/src/views/teacher/TeacherScaffoldingPage.vue
@@ -50,6 +50,11 @@
           <span class="badge primary">맞춤 추천</span>
         </div>
 
+        <div v-if="loading" class="status-banner spaced-sm">
+          <strong>새 스캐폴딩 추천을 생성 중입니다.</strong>
+          <p>학생 상태와 선택 과목을 바탕으로 근거 기준과 활동까지 함께 정리하고 있습니다.</p>
+        </div>
+
         <div class="mini-grid spaced">
           <label>
             <span class="section-label">학년</span>
@@ -58,8 +63,9 @@
           <label>
             <span class="section-label">과목</span>
             <select v-model="form.subject" class="input-like spaced-sm">
-              <option>수학</option>
-              <option>국어</option>
+              <option v-for="subject in subjectOptions" :key="subject.slug" :value="subject.label">
+                {{ subject.label }}
+              </option>
             </select>
           </label>
         </div>
@@ -155,12 +161,12 @@
           </article>
         </div>
         <button
-          v-if="activities.length > SUMMARY_LIMIT"
+          v-if="activities.length > ACTIVITY_PREVIEW_LIMIT"
           type="button"
           class="inline-more-button spaced-sm"
           @click="showAllActivities = !showAllActivities"
         >
-          {{ showAllActivities ? '추천 활동 접기' : `추천 활동 ${activities.length - SUMMARY_LIMIT}개 더 보기` }}
+          {{ showAllActivities ? '추천 활동 접기' : `추천 활동 ${activities.length - ACTIVITY_PREVIEW_LIMIT}개 더 보기` }}
         </button>
       </section>
     </main>
@@ -215,9 +221,11 @@ import {
   getStudentProgress,
   mapLevelToKorean,
 } from '../../api'
+import { useCurriculumSubjects } from '../../composables/useCurriculumSubjects'
 import { useStudentStore } from '../../composables/useStudentStore'
 
 const { state: studentStore } = useStudentStore()
+const { subjectOptions, loadCurriculumSubjects } = useCurriculumSubjects()
 
 const loading = ref(false)
 const recommendation = ref(null)
@@ -225,12 +233,21 @@ const feedbacks = ref([])
 const showAllGaps = ref(false)
 const showAllActivities = ref(false)
 const SUMMARY_LIMIT = 3
+const ACTIVITY_PREVIEW_LIMIT = 4
 const form = reactive({
   grade: '초등학교 3학년',
   subject: '수학',
   teacher_description:
     '수 모형을 보여주면 덧셈 활동을 시작하지만, 받아올림 단계에서 멈추고 도움 요청을 하지 못합니다.',
 })
+
+function ensureSelectedSubject(currentValue) {
+  if (!subjectOptions.value.length) return currentValue
+  const isValid = subjectOptions.value.some(
+    (subject) => subject.label === currentValue || subject.slug === currentValue,
+  )
+  return isValid ? currentValue : subjectOptions.value[0].label
+}
 
 const studentName = computed(() => studentStore.student?.name || '이지훈')
 const studentProfile = computed(() => [
@@ -259,7 +276,7 @@ const visibleGapItems = computed(() =>
   showAllGaps.value ? gapItems.value : gapItems.value.slice(0, SUMMARY_LIMIT),
 )
 const visibleActivities = computed(() =>
-  showAllActivities.value ? activities.value : activities.value.slice(0, SUMMARY_LIMIT),
+  showAllActivities.value ? activities.value : activities.value.slice(0, ACTIVITY_PREVIEW_LIMIT),
 )
 
 const standard = computed(() => recommendation.value?.achievement_standard || null)
@@ -355,6 +372,8 @@ async function requestRecommendation() {
 }
 
 onMounted(async () => {
+  await loadCurriculumSubjects()
+  form.subject = ensureSelectedSubject(form.subject)
   const progressData = await getStudentProgress()
   feedbacks.value = progressData.feedbacks || []
 })


### PR DESCRIPTION
## 변경 내용
- 실제 API 응답 구조에 맞게 프론트 파싱 로직을 보완했습니다.
- 교사용/학부모용 주요 화면에서 추천 결과, 근거 성취기준, 기록 영역의 가독성을 개선했습니다.
- 과목 선택 로직을 공통 composable로 분리해 확장 과목 반영을 쉽게 했습니다.
- 선택교과/통합교과 등 확장된 과목 목록이 각 화면에서 일관되게 보이도록 정리했습니다.

## 주요 반영 사항
- `client/src/api/index.js`
  - 실제 백엔드 응답 정규화 및 파싱 보완
- `client/src/composables/useCurriculumSubjects.js`
  - 과목 목록 공통 관리 로직 추가
- `client/src/views/teacher/*`
  - 추천 결과, 기준, 진행 기록, 상세 화면 가독성 개선
- `client/src/views/parent/*`
  - 학부모 화면 레이아웃 및 표시 일관성 개선
- `client/src/App.vue`, `client/src/style.css`
  - 공통 UI 동작 및 스타일 보정

## 기대 효과
- 실제 API 연동 시 화면이 깨지지 않고 안정적으로 데이터를 표시할 수 있습니다.
- 과목이 추가되더라도 프론트에서 더 쉽게 확장할 수 있습니다.
- 교사/학부모 화면 모두 정보 구조가 더 자연스럽고 읽기 쉬워졌습니다.

## 확인 사항
- 교사용/학부모용 주요 탭 진입 및 화면 전환 확인
- 추천 결과 / 근거 성취기준 / 최근 기록 표시 확인
- 과목 선택 목록 확장 반영 확인