### PR TITLE
Remove frontend demo fallback data

### DIFF
--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -124,7 +124,7 @@ const parentItems = [
 const navItems = computed(() => (isTeacherRoute.value ? teacherItems : parentItems))
 const studentDisplayName = computed(() => {
   const name = studentStore.student?.name?.trim()
-  return name || '이지훈'
+  return name || '학생'
 })
 const railAvatarLabel = computed(() => {
   const name = studentDisplayName.value.replace(/\s+/g, '')

--- a/client/src/api/index.js
+++ b/client/src/api/index.js
@@ -314,234 +314,24 @@ function normalizeCareerRecommendationPayload(data) {
   return next
 }
 
-const sampleStudent = {
-  id: 1,
-  name: '이지훈',
-  disability_type: '자폐 스펙트럼',
-  additional_diagnoses: 'ADHD',
-  current_level: '초등 3학년 수준 읽기/쓰기 보조 필요',
-  behavioral_traits: '어려운 과제를 만나면 감정이 급격히 올라감',
+const emptyStudent = null
+const emptyProgress = { feedbacks: [], progress_summary: '' }
+const emptySchoolLife = {
+  lunch_menu: '',
+  dismissal_time: '',
+  academic_calendar: '',
+  today_timetable: [],
+  tomorrow_prep: [],
 }
-
-const sampleProgress = {
-  feedbacks: [
-    {
-      id: 1,
-      performance: 'AI 분석: 중 수준',
-      scaffolding_effectiveness: 'AI 추천 적용 전',
-      disability_type: '자폐성 장애',
-      teacher_description: '읽기 시간에 집중이 흐트러졌지만 짧은 지시에는 잘 반응함',
-      llm_analysis: {
-        detected_level: '중',
-        learning_gaps: ['한 번에 여러 지시를 처리하는 데 어려움', '과제 전환 시 예고 없이 바뀌면 멈춤'],
-        recommended_strategies: ['한 문장·한 단계 지시', '시각 일정표로 전환 예고', '완료 직후 구체적 강화'],
-        confidence_score: 0.88,
-        analysis_summary: '짧고 예측 가능한 지시가 주어질 때 참여도가 높아집니다.',
-      },
-      scaffolding_recommendations: {
-        recommended_level: '중',
-        rationale: '짧은 지시와 시각 단서 제공 시 과제 지속 시간이 늘어납니다.',
-        scaffolding_details: {
-          level: '중',
-          description: '언어적 안내와 시각적 힌트를 병행합니다.',
-          activities: [
-            {
-              name: '핵심 문장 찾기',
-              description: '짧은 문단에서 핵심 문장을 색 스티커로 표시합니다.',
-              duration: '15분',
-              materials: ['기본 교재', '색 스티커'],
-            },
-          ],
-          strategies: ['한 번에 한 단계 지시', '시각 일정표 제시', '성공 즉시 강화 피드백'],
-        },
-        achievement_standard: {
-          grade: '3',
-          subject: '국어',
-          standard_text: '중심 내용을 짐작하고 듣거나 읽은 내용을 다른 표현으로 나타낼 수 있다.',
-          relevance_score: 0.72,
-        },
-        additional_notes: '가정에서도 동일한 지시 방식을 유지하면 전환이 안정됩니다.',
-      },
-      created_at: '2026-04-21T09:30:00',
-    },
-    {
-      id: 2,
-      performance: 'AI 분석: 상 수준',
-      scaffolding_effectiveness: '시각 자료 적용 후',
-      disability_type: '자폐성 장애',
-      teacher_description: '수학 활동에서 시각 자료를 활용하니 참여도가 높아짐',
-      llm_analysis: {
-        detected_level: '상',
-        learning_gaps: ['복잡한 언어 설명만 있을 때 시작이 늦음'],
-        recommended_strategies: ['수 모형·그림 단서 먼저 제시', '문제를 두 단계로 나누기'],
-        confidence_score: 0.81,
-        analysis_summary: '구체적 자료가 먼저 제시되면 스스로 절차를 이어가는 경향이 있습니다.',
-      },
-      scaffolding_recommendations: {
-        recommended_level: '상',
-        rationale: '시각 자료와 구조화된 순서가 있으면 독립에 가까운 수행이 가능합니다.',
-        scaffolding_details: {
-          level: '상',
-          description: '확인 질문과 선택지 중심으로 최소 개입을 유지합니다.',
-          activities: [
-            {
-              name: '스스로 순서 말하기',
-              description: '풀이 후 스스로 단계를 말로 정리하게 합니다.',
-              duration: '10분',
-              materials: ['학습지'],
-            },
-          ],
-          strategies: ['완료 후 요약 질문', '틀렸을 때 힌트 한 가지만 제시'],
-        },
-        achievement_standard: {
-          grade: '3',
-          subject: '수학',
-          standard_text: '덧셈과 뺄셈의 의미를 이해하고 다양한 방법으로 계산할 수 있다.',
-          relevance_score: 0.68,
-        },
-        additional_notes: '전문가 상담 권고 등 추가 메모가 있으면 기록에 남깁니다.',
-      },
-      created_at: '2026-04-23T10:10:00',
-    },
-  ],
-  progress_summary: '',
+const emptyScaffolding = null
+const emptyCurriculumResults = { query: '', count: 0, results: [] }
+const emptyCareerSearch = { query: '', count: 0, results: [] }
+const emptyCareerRecommendation = {
+  current_skills: '',
+  recommended_careers: [],
+  skill_gaps: [],
+  career_paths: [],
 }
-
-const FIXED_TOMORROW_PREP = ['체육복', '색연필', '국어 공책']
-
-const sampleSchoolLife = {
-  lunch_menu: '참치야채비빔밥, 북어국, 갈릭미트볼야채볶음, 고구마맛탕, 백김치, 우유컵케익',
-  dismissal_time: '16:15',
-  academic_calendar: '일정 없음',
-  today_timetable: ['종교와 삶Ⅰ', '수학', '음악', '기술·가정', '사회', '과학', '(창)자율·자치활동'],
-  tomorrow_prep: FIXED_TOMORROW_PREP,
-}
-
-const sampleScaffolding = normalizeScaffoldingApiResponse({
-  recommended_level: '하',
-  rationale:
-    "학생의 현재 능력 수준을 '하'로 평가. 주요 학습 격차: 실생활 문제 연산 도출, 세로셈 자릿값 계산 등. 신뢰도: 0.72",
-  scaffolding_details: {
-    level: '하',
-    description:
-      '문제 해결을 돕는 삽화나 도식을 활용하여 이해 지원; 식 도출을 중점으로 지도하며 계산 방법은 학생의 자율성 존중',
-    activities: [
-      {
-        name: '교육과정 활동 1',
-        description: '거스름돈 계산이나 물건 수 합산 문제를 짧은 단계로 나누어 반복 연습',
-      },
-      {
-        name: '교육과정 활동 2',
-        description: '실생활 상황을 보고 연산 식을 도출하기를 짧은 단계로 나누어 반복 연습',
-      },
-      {
-        name: '교육과정 활동 3',
-        description: '구체물로 상황을 재현하고 전체/남은 수를 구하기를 짧은 단계로 나누어 반복 연습',
-      },
-    ],
-    strategies: [
-      '세로셈 지도 시 자릿값 위치를 시각적으로 가이드 함',
-      '구체물 10개 묶음을 더하거나 빼며 전체 개수 확인',
-      '문제 해결을 돕는 삽화나 도식을 활용하여 이해 지원',
-      '식 도출을 중점으로 지도하며 계산 방법은 학생의 자율성 존중',
-    ],
-  },
-  achievement_standard: {
-    standard_id: '6수학01-08',
-    standard_text: '받아올림(내림)이 없는 몇십의 덧셈, 뺄셈과 관련된 실생활 문제를 해결한다.',
-    grade: '6',
-    subject: 'math',
-    disability_type: '중도중복장애',
-    relevance_score: 0.5676,
-  },
-  related_achievement_standards: [
-    '[6수학01-08] 받아올림(내림)이 없는 몇십의 덧셈, 뺄셈과 관련된 실생활 문제를 해결한다. (관련도 0.57)',
-    '[6수학01-07] 받아올림(내림)이 없는 몇십의 덧셈과 뺄셈을 한다. (관련도 0.56)',
-    '[4수학01-03] 9 이하의 수를 읽고 쓴다. (관련도 0.52)',
-  ],
-})
-
-const sampleCurriculumResults = {
-  query: '',
-  count: 2,
-  results: [
-    {
-      content: '국어 읽기: 주요 낱말의 의미를 문맥에서 파악한다.',
-      metadata: { subject: '국어', grade: '초3' },
-      score: 0.84,
-    },
-    {
-      content: '수학: 두 자리 수의 덧셈과 뺄셈 과정을 설명할 수 있다.',
-      metadata: { subject: '수학', grade: '초3' },
-      score: 0.81,
-    },
-  ],
-}
-
-const sampleCareerSearch = {
-  query: '',
-  count: 2,
-  results: [
-    {
-      job_title: '디지털 콘텐츠 디자이너',
-      required_skills: ['시각 표현', '도구 활용', '협업 커뮤니케이션'],
-      skill_gap: {
-        gap_skills: ['도구 활용', '협업 커뮤니케이션'],
-        development_suggestions: [
-          '- 도구 활용: 기초 디자인 툴 사용 경험 쌓기',
-          '- 협업 커뮤니케이션: 팀 프로젝트 참여로 소통 역량 강화',
-        ],
-      },
-      score: 0.79,
-    },
-    {
-      job_title: '서비스 도우미 트레이너',
-      required_skills: ['절차 이해', '상황 대응', '대인 소통'],
-      skill_gap: {
-        gap_skills: ['상황 대응'],
-        development_suggestions: ['- 상황 대응: 역할 놀이 기반 시나리오 훈련'],
-      },
-      score: 0.75,
-    },
-  ],
-}
-
-const sampleCareerRecommendation = normalizeCareerRecommendationPayload({
-  current_skills: '손작업과 순서 기억이 안정적이며 시각 자료를 활용한 활동에 오래 참여합니다.',
-  recommended_careers: [
-    { job_title: '캐릭터디자이너', category: '예술분야(전문직)', match_score: 0.508 },
-    { job_title: '화가', category: '예술분야(전문직)', match_score: 0.475 },
-    { job_title: '일러스트레이터', category: '예술분야(전문직)', match_score: 0.472 },
-  ],
-  skill_gaps: [
-    {
-      job_title: '캐릭터디자이너',
-      gap_skills: ['손재능', '공간시각능력', '창의력', '기발한 발상', '컴퓨터 그래픽 지식'],
-      development_suggestions: [
-        '핵심 역량을 10~15분 단위 반복 과제로 나눠 연습',
-        '체크리스트 기반으로 과제 시작-중간-완료 단계를 시각화',
-        '주 1회 동일 과업 재수행으로 수행 정확도를 기록',
-      ],
-    },
-    {
-      job_title: '화가',
-      gap_skills: ['미적 감각', '색채 구성', '창의력'],
-      development_suggestions: ['짧은 스케치 루틴으로 관찰·표현 연습', '완성보다 과정 기록에 칭찬 집중'],
-    },
-  ],
-  career_paths: [
-    {
-      target_career: '캐릭터디자이너',
-      estimated_timeline: '6~12개월',
-      stages: [
-        { stage: '현재', focus: '현재 강점 파악', description: '직무 요구 역량과 현재 역량 비교' },
-        { stage: '단기(1~3개월)', focus: '핵심 기초 역량 강화', description: '손재능·공간시각능력·창의력 중심 반복 과제' },
-        { stage: '중기(3~6개월)', focus: '실습 기반 적용', description: '체크리스트 기반 모의/현장 실습' },
-        { stage: '장기(6개월+)', focus: '직무 전환 및 유지', description: '실제 업무 환경 역할 확장 + 피드백 루프' },
-      ],
-    },
-  ],
-})
 
 function withFallback(requestFn, fallbackData) {
   return requestFn().catch(() => fallbackData)
@@ -577,7 +367,7 @@ function normalizeCurriculumSubjectOptions(payload) {
     .filter(Boolean)
 
   if (!subjects.length) {
-    return DEFAULT_CURRICULUM_SUBJECTS.map((subject) => ({ ...subject }))
+    return []
   }
 
   const deduped = []
@@ -598,21 +388,18 @@ function toGradeCode(grade) {
 }
 
 export function getStudent() {
-  return withFallback(async () => (await apiClient.get('/student/')).data, sampleStudent)
+  return withFallback(async () => (await apiClient.get('/student/')).data, emptyStudent)
 }
 
 export function patchStudentTraits(payload) {
-  return withFallback(async () => (await apiClient.patch('/student/', payload)).data, {
-    ...sampleStudent,
-    ...payload,
-  })
+  return withFallback(async () => (await apiClient.patch('/student/', payload)).data, payload)
 }
 
 export function getStudentProgress() {
   return withFallback(async () => {
     const data = (await apiClient.get('/student/progress')).data
     return normalizeProgressPayload(data)
-  }, normalizeProgressPayload(sampleProgress))
+  }, emptyProgress)
 }
 
 export async function deleteStudentFeedbacks({ feedback_ids = [], delete_all = false } = {}) {
@@ -625,15 +412,15 @@ export async function deleteStudentFeedbacks({ feedback_ids = [], delete_all = f
 export function getSchoolLife() {
   return withFallback(async () => {
     const data = (await apiClient.get('/student/school-life')).data
-    return { ...(data && typeof data === 'object' ? data : {}), tomorrow_prep: FIXED_TOMORROW_PREP }
-  }, { ...sampleSchoolLife, tomorrow_prep: FIXED_TOMORROW_PREP })
+    return data && typeof data === 'object' ? data : {}
+  }, emptySchoolLife)
 }
 
 export function getScaffoldingRecommendation(payload) {
   return withFallback(async () => {
     const data = (await apiClient.post('/rag/scaffolding-recommendation', payload)).data
     return normalizeScaffoldingApiResponse(data)
-  }, sampleScaffolding)
+  }, emptyScaffolding)
 }
 
 export function getCurriculumSubjects() {
@@ -651,14 +438,14 @@ export function searchCurriculum(query, params = {}) {
   }
   return withFallback(
     async () => (await apiClient.get('/rag/curriculum-search', { params: { query, ...normalizedParams } })).data,
-    { ...sampleCurriculumResults, query },
+    { ...emptyCurriculumResults, query },
   )
 }
 
 export function searchCareer(query, params = {}) {
   return withFallback(
     async () => (await apiClient.get('/rag/career-search', { params: { query, ...params } })).data,
-    { ...sampleCareerSearch, query },
+    { ...emptyCareerSearch, query },
   )
 }
 
@@ -666,8 +453,5 @@ export function getCareerRecommendation(payload) {
   return withFallback(async () => {
     const data = (await apiClient.post('/rag/career-recommendation', payload)).data
     return normalizeCareerRecommendationPayload(data)
-  }, {
-    ...sampleCareerRecommendation,
-    current_skills: payload?.current_skills || sampleCareerRecommendation.current_skills,
-  })
+  }, { ...emptyCareerRecommendation, current_skills: payload?.current_skills || '' })
 }

--- a/client/src/components/StudentProfileHeader.vue
+++ b/client/src/components/StudentProfileHeader.vue
@@ -4,7 +4,7 @@
       <div>
         <p class="text-xs font-bold uppercase tracking-[0.16em] text-slate-400">Student Profile</p>
         <h2 class="mt-2 text-2xl font-black tracking-normal text-slate-950">
-          {{ student?.name || '이지훈' }}
+          {{ student?.name || '학생 정보 없음' }}
         </h2>
         <p class="mt-2 max-w-3xl text-sm leading-6 text-slate-600">
           {{ student?.current_level || '현재 수준을 입력하면 추천과 요약이 더 정확해집니다.' }}

--- a/client/src/composables/useCurriculumSubjects.js
+++ b/client/src/composables/useCurriculumSubjects.js
@@ -1,13 +1,8 @@
 import { computed, reactive, readonly } from 'vue'
 import { getCurriculumSubjects } from '../api'
 
-const FALLBACK_SUBJECTS = [
-  { slug: 'math', label: '수학' },
-  { slug: 'korean', label: '국어' },
-]
-
 const state = reactive({
-  subjects: FALLBACK_SUBJECTS.map((subject) => ({ ...subject })),
+  subjects: [],
   loading: false,
   loaded: false,
   error: '',
@@ -20,14 +15,12 @@ async function loadCurriculumSubjects(force = false) {
   state.error = ''
   try {
     const subjects = await getCurriculumSubjects()
-    state.subjects = Array.isArray(subjects) && subjects.length
-      ? subjects
-      : FALLBACK_SUBJECTS.map((subject) => ({ ...subject }))
+    state.subjects = Array.isArray(subjects) ? subjects : []
     state.loaded = true
     return state.subjects
   } catch (error) {
     state.error = '과목 목록을 불러오지 못했습니다.'
-    state.subjects = FALLBACK_SUBJECTS.map((subject) => ({ ...subject }))
+    state.subjects = []
     console.error(error)
     return state.subjects
   } finally {
@@ -36,9 +29,7 @@ async function loadCurriculumSubjects(force = false) {
 }
 
 export function useCurriculumSubjects() {
-  const subjectOptions = computed(() =>
-    state.subjects.length ? state.subjects : FALLBACK_SUBJECTS,
-  )
+  const subjectOptions = computed(() => state.subjects)
 
   return {
     state: readonly(state),

--- a/client/src/views/ParentDashboard.vue
+++ b/client/src/views/ParentDashboard.vue
@@ -157,13 +157,11 @@ async function onSaveTraits() {
 }
 
 async function onSearchCareer() {
-  const result = await searchCareer(careerInterest.value || '창작 활동과 손작업')
+  const result = await searchCareer(careerInterest.value)
   careerResults.value = result.results || []
 }
 
 onMounted(async () => {
   schoolLife.value = await getSchoolLife()
-  const result = await searchCareer('시각 활동과 의사소통')
-  careerResults.value = result.results || []
 })
 </script>

--- a/client/src/views/TeacherDashboard.vue
+++ b/client/src/views/TeacherDashboard.vue
@@ -169,14 +169,12 @@ async function onRecommendScaffolding() {
 }
 
 async function onSearchCurriculum() {
-  const result = await searchCurriculum(curriculumQuery.value || '기초 학습 집중')
+  const result = await searchCurriculum(curriculumQuery.value)
   curriculumResults.value = result.results || []
 }
 
 onMounted(async () => {
   const progressData = await getStudentProgress()
   progressFeedbacks.value = progressData.feedbacks || []
-  const searchResult = await searchCurriculum('읽기와 수학 기초')
-  curriculumResults.value = searchResult.results || []
 })
 </script>

--- a/client/src/views/parent/ParentCareerPage.vue
+++ b/client/src/views/parent/ParentCareerPage.vue
@@ -125,8 +125,8 @@ const { state: studentStore } = useStudentStore()
 const route = useRoute()
 
 const loading = ref(false)
-const currentSkills = ref('손작업과 순서 기억이 안정적이고, 그림 자료를 보면 활동을 오래 지속합니다.')
-const interests = ref('요리, 만들기, 정리')
+const currentSkills = ref('')
+const interests = ref('')
 const careerRecommendation = ref(null)
 const searchResults = ref([])
 const routeSearchQuery = computed(() => (typeof route.query.q === 'string' ? route.query.q.trim() : ''))
@@ -140,7 +140,7 @@ const recommendedCareers = computed(() =>
 const skillGaps = computed(() =>
   careerRecommendation.value?.skill_gaps?.length
     ? careerRecommendation.value.skill_gaps.slice(0, 3)
-    : ['도구 이름 익히기', '작업 순서 말하기', '도움 요청하기'],
+    : [],
 )
 
 const pathStages = computed(() => careerRecommendation.value?.career_paths?.[0]?.stages || [])

--- a/client/src/views/parent/ParentOverviewPage.vue
+++ b/client/src/views/parent/ParentOverviewPage.vue
@@ -36,8 +36,8 @@
         </div>
 
         <div class="callout spaced">
-          <strong>숙제 전 2단계 계획을 먼저 보여주세요.</strong>
-          <p>활동을 시작하기 전 “먼저 공책 펴기, 다음 문제 3개 풀기”처럼 짧은 순서를 확인하면 전환이 안정됩니다.</p>
+          <strong>{{ homeSupportTitle }}</strong>
+          <p>{{ homeSupportCopy }}</p>
         </div>
 
         <div class="list-stack spaced">
@@ -143,16 +143,23 @@ const progressSummary = computed(() => {
   return count > 0 ? `총 ${count}개의 피드백 기록이 있습니다.` : '아직 누적된 피드백 기록이 없습니다.'
 })
 const recentChanges = computed(() => {
-  if (!feedbacks.value.length) {
-    return ['그림 단서가 있을 때 집중 시간이 늘어납니다.', '활동 전환 전 예고가 있으면 불안이 줄어듭니다.']
-  }
+  if (!feedbacks.value.length) return []
   return feedbacks.value
     .slice(-3)
     .reverse()
     .map((feedback) => feedback.teacher_description || feedback.performance || '최근 기록이 저장되었습니다.')
 })
 
-const prepList = computed(() => schoolLife.value.tomorrow_prep || ['체육복', '색연필', '국어 공책'])
+const prepList = computed(() => schoolLife.value.tomorrow_prep || [])
+
+const homeSupportTitle = computed(() =>
+  feedbacks.value.length ? '최근 피드백을 확인해 주세요.' : '가정 지원 정보 대기',
+)
+const homeSupportCopy = computed(() =>
+  feedbacks.value.length
+    ? '저장된 피드백을 바탕으로 집에서 이어갈 지원을 확인할 수 있습니다.'
+    : 'mock API 또는 실제 API에서 피드백을 받아오면 가정 지원 내용이 표시됩니다.',
+)
 
 const supportSteps = [
   { title: '보여주기', copy: '말로 길게 설명하기보다 그림 또는 짧은 목록을 먼저 보여주세요.' },

--- a/client/src/views/parent/ParentSchoolPage.vue
+++ b/client/src/views/parent/ParentSchoolPage.vue
@@ -114,9 +114,9 @@ const schoolLife = ref({})
 const lunch = computed(() => schoolLife.value.lunch_menu || '정보 없음')
 const timetable = computed(() => {
   const items = schoolLife.value.today_timetable || []
-  return items.length ? items : ['국어', '수학', '미술']
+  return items
 })
-const prepList = computed(() => schoolLife.value.tomorrow_prep || ['체육복', '색연필', '국어 공책'])
+const prepList = computed(() => schoolLife.value.tomorrow_prep || [])
 
 const mainCards = computed(() => [
   { label: '점심', value: shortText(lunch.value), caption: '급식' },

--- a/client/src/views/teacher/TeacherCareerPage.vue
+++ b/client/src/views/teacher/TeacherCareerPage.vue
@@ -180,8 +180,8 @@ import { useStudentStore } from '../../composables/useStudentStore'
 const { state: studentStore } = useStudentStore()
 const route = useRoute()
 
-const currentSkills = ref('손작업과 순서 기억이 안정적이며, 시각 자료를 활용한 활동에 오래 참여합니다.')
-const interestText = ref('그림 카드, 요리 활동, 반복 루틴')
+const currentSkills = ref('')
+const interestText = ref('')
 const careerRecommendation = ref(null)
 const selectedIndex = ref(0)
 const loading = ref(false)
@@ -261,8 +261,7 @@ watch(routeSearchQuery, async (query) => {
   await createRecommendation()
 })
 
-onMounted(async () => {
+onMounted(() => {
   if (routeSearchQuery.value) currentSkills.value = routeSearchQuery.value
-  await createRecommendation()
 })
 </script>

--- a/client/src/views/teacher/TeacherCurriculumPage.vue
+++ b/client/src/views/teacher/TeacherCurriculumPage.vue
@@ -172,8 +172,8 @@ const loading = ref(false)
 const results = ref([])
 const selectedIndex = ref(0)
 const filters = reactive({
-  query: '수 모형을 활용한 덧셈과 받아올림 단계 지원',
-  subject: '수학',
+  query: '',
+  subject: '',
   grade: '',
   disability_type: '',
 })
@@ -247,7 +247,7 @@ function extractSectionItems(content, sectionTitle) {
 async function runSearch() {
   loading.value = true
   try {
-    const response = await searchCurriculum(filters.query || '기초 학습 지원', {
+    const response = await searchCurriculum(filters.query, {
       subject: filters.subject || undefined,
       grade: filters.grade || undefined,
       disability_type: filters.disability_type || studentStore.student?.disability_type || undefined,

--- a/client/src/views/teacher/TeacherOverviewPage.vue
+++ b/client/src/views/teacher/TeacherOverviewPage.vue
@@ -291,9 +291,7 @@ import { useStudentStore } from '../../composables/useStudentStore'
 const { state: studentStore } = useStudentStore()
 const { subjectOptions, loadCurriculumSubjects } = useCurriculumSubjects()
 
-const observationDraft = ref(
-  '수학 활동에서 수 모형을 보여주면 문제 풀이를 시작하지만, 말로만 설명하면 첫 단계에서 멈추고 도움을 요청하지 못합니다.',
-)
+const observationDraft = ref('')
 const progress = ref({ feedbacks: [], progress_summary: '' })
 const quickRecommendation = ref(null)
 const loadingRecommendation = ref(false)
@@ -315,16 +313,16 @@ function ensureSelectedSubject(currentValue) {
   return isValid ? currentValue : subjectOptions.value[0].label
 }
 
-const studentName = computed(() => studentStore.student?.name || '이지훈')
+const studentName = computed(() => studentStore.student?.name || '학생 정보 없음')
 
 const studentCards = computed(() => [
   {
     label: '현재 수준',
-    value: studentStore.student?.current_level || '초등 3학년 수준 · 구체적 연산 단계에서 개별 지원 필요',
+    value: studentStore.student?.current_level || '정보 없음',
   },
   {
     label: '장애 유형',
-    value: studentStore.student?.disability_type || '경도 지적장애 · ADHD (프로필 등록 시 서버에 반영)',
+    value: studentStore.student?.disability_type || '정보 없음',
   },
   {
     label: '동반 진단',
@@ -332,9 +330,7 @@ const studentCards = computed(() => [
   },
   {
     label: '과제·주의 특성',
-    value:
-      studentStore.student?.behavioral_traits ||
-      '말로만 된 설명보다 시각·순서 단서가 있을 때 과제 지속 시간이 길어짐 · 전환 시 예고 필요',
+    value: studentStore.student?.behavioral_traits || '정보 없음',
   },
 ])
 
@@ -344,7 +340,7 @@ const progressSummary = computed(() => {
   return count > 0 ? `총 ${count}개의 피드백 기록이 있습니다.` : '아직 누적된 피드백 기록이 없습니다.'
 })
 const latestFeedback = computed(() => feedbacks.value.at(-1) || null)
-const latestLevel = computed(() => latestFeedback.value?.llm_analysis?.detected_level || '중')
+const latestLevel = computed(() => latestFeedback.value?.llm_analysis?.detected_level || '')
 
 const sideMetrics = computed(() => [
   { label: '기록 수', value: feedbacks.value.length, caption: '누적 피드백' },
@@ -356,16 +352,13 @@ const feedbackPreview = computed(() => feedbacks.value.slice(-3).reverse())
 const strategies = computed(() =>
   quickRecommendation.value?.scaffolding_details?.strategies?.length
     ? quickRecommendation.value.scaffolding_details.strategies
-    : previewStrategies,
+    : [],
 )
 
 const activities = computed(() =>
   quickRecommendation.value?.scaffolding_details?.activities?.length
     ? quickRecommendation.value.scaffolding_details.activities
-    : [
-        { name: '단계 카드 정렬', description: '풀이 순서를 카드로 먼저 놓고 한 단계씩 수행합니다.' },
-        { name: '도움 요청 문장 연습', description: '멈춘 지점에서 사용할 짧은 요청 문장을 선택하게 합니다.' },
-      ],
+    : [],
 )
 
 const gapItems = computed(() => splitDisplayItems(rationaleSections.value?.gap))
@@ -436,12 +429,7 @@ const evidenceList = computed(() => {
     .filter(Boolean)
 })
 
-const previewStrategies = [
-  '한 번에 한 단계만 제시',
-  '수 모형 또는 그림 단서 먼저 제공',
-  '완료 직후 구체적인 강화',
-  '도움 요청 문장 카드 제공',
-]
+const previewStrategies = []
 
 const priorityList = computed(() => {
   const aiPoints = quickRecommendation.value?.teaching_points
@@ -485,12 +473,7 @@ const priorityList = computed(() => {
     items.push(`${standard.value.standard_id} 기준과 연결해 성공 조건을 관찰`)
   }
 
-  const fallbackItems = [
-    '수업 시작 전 학생의 컨디션과 과제 지속 가능 시간을 확인',
-    '처음 과제는 짧게 제시하고 성공 직후 구체적으로 강화',
-    '도움 강도는 관찰 반응에 맞춰 한 단계씩 줄이기',
-    '다음 활동 전 전환 신호를 미리 안내',
-  ]
+  const fallbackItems = []
 
   const unique = [...new Set(items.filter(Boolean))]
   fallbackItems.forEach((item) => {

--- a/client/src/views/teacher/TeacherProgressPage.vue
+++ b/client/src/views/teacher/TeacherProgressPage.vue
@@ -240,7 +240,7 @@ const selectedFeedback = computed(() =>
   orderedFeedbacks.value[0] ||
   null,
 )
-const latestLevel = computed(() => selectedFeedback.value?.llm_analysis?.detected_level || '중')
+const latestLevel = computed(() => selectedFeedback.value?.llm_analysis?.detected_level || '')
 const progressSummary = computed(() => {
   const count = feedbacks.value.length
   return count > 0 ? `총 ${count}개의 피드백 기록이 있습니다.` : '아직 누적된 피드백 기록이 없습니다.'

--- a/client/src/views/teacher/TeacherScaffoldingPage.vue
+++ b/client/src/views/teacher/TeacherScaffoldingPage.vue
@@ -237,8 +237,7 @@ const ACTIVITY_PREVIEW_LIMIT = 4
 const form = reactive({
   grade: '초등학교 3학년',
   subject: '수학',
-  teacher_description:
-    '수 모형을 보여주면 덧셈 활동을 시작하지만, 받아올림 단계에서 멈추고 도움 요청을 하지 못합니다.',
+  teacher_description: '',
 })
 
 function ensureSelectedSubject(currentValue) {
@@ -249,9 +248,9 @@ function ensureSelectedSubject(currentValue) {
   return isValid ? currentValue : subjectOptions.value[0].label
 }
 
-const studentName = computed(() => studentStore.student?.name || '이지훈')
+const studentName = computed(() => studentStore.student?.name || '학생 정보 없음')
 const studentProfile = computed(() => [
-  { label: '현재 수준', value: studentStore.student?.current_level || '초등 3학년 수준 입력 대기' },
+  { label: '현재 수준', value: studentStore.student?.current_level || '정보 없음' },
   { label: '장애 유형', value: studentStore.student?.disability_type || '정보 없음' },
   { label: '행동 특성', value: studentStore.student?.behavioral_traits || '관찰 필요' },
 ])
@@ -259,16 +258,13 @@ const studentProfile = computed(() => [
 const strategies = computed(() =>
   recommendation.value?.scaffolding_details?.strategies?.length
     ? recommendation.value.scaffolding_details.strategies
-    : ['한 번에 한 단계만 제시', '시각 단서를 먼저 제시', '완료 직후 강화'],
+    : [],
 )
 
 const activities = computed(() =>
   recommendation.value?.scaffolding_details?.activities?.length
     ? recommendation.value.scaffolding_details.activities
-    : [
-        { name: '단계 카드 정렬', description: '풀이 순서를 카드로 먼저 놓고 한 단계씩 수행합니다.' },
-        { name: '도움 요청 문장 연습', description: '멈춘 지점에서 사용할 짧은 요청 문장을 선택하게 합니다.' },
-      ],
+    : [],
 )
 
 const gapItems = computed(() => splitDisplayItems(detailRationaleSections.value?.gap))
@@ -289,7 +285,7 @@ const detailConfidence = computed(() => detailRationaleSections.value?.confidenc
 const relatedStandards = computed(() =>
   recommendation.value?.related_achievement_standards?.length
     ? recommendation.value.related_achievement_standards
-    : ['추천과 함께 참고할 성취기준이 여기에 표시됩니다.'],
+    : [],
 )
 
 function levelLabel(level) {


### PR DESCRIPTION
# 프론트엔드 데모 기본 데이터 제거

## 변경 목적

1차 심사 시 실제 API 대신 mock API 한 건으로 시연할 예정이므로, 프론트엔드 내부에 남아 있던 하드코딩 기본 데이터가 mock 응답처럼 보이지 않도록 제거했습니다.

이제 API 또는 mock API에서 데이터가 오기 전에는 학생 정보, 학교생활, 추천 결과, 진로 결과, 성취기준 검색 결과가 빈 상태 또는 대기 상태로 표시됩니다.

## 주요 변경 사항

- API 실패 시 반환하던 샘플 학생/진도/학교생활/스캐폴딩/진로/교육과정 데이터를 제거했습니다.
- `이지훈`, 기본 관찰 문장, 기본 진로 관심사, 기본 과목 검색어, 기본 시간표/준비물 같은 시연용 초기값을 제거했습니다.
- 추천/검색 화면은 mock API 또는 실제 API 응답이 있을 때만 결과를 표시하도록 변경했습니다.
- 과목 목록은 프론트엔드 기본값으로 채우지 않고 API 응답 기반으로 표시하도록 정리했습니다.
- 누적 피드백이 없을 때 `중` 수준처럼 보이던 기본 분석값을 제거했습니다.

## 파일별 변경 코멘트

### `client/src/App.vue`

하드코딩된 학생 fallback 이름을 중립적인 `학생` 라벨로 변경했습니다.

### `client/src/api/index.js`

샘플 학생, 진행 기록, 학교생활, 스캐폴딩 추천, 교육과정 검색, 진로 검색/추천 fallback 데이터를 제거했습니다. API 요청 실패 시 데모 데이터 대신 빈 응답을 반환하도록 변경했습니다.

### `client/src/components/StudentProfileHeader.vue`

프로필 헤더에서 데모 학생명 fallback을 제거하고, 학생 정보가 없을 때 명확한 빈 상태 문구가 보이도록 변경했습니다.

### `client/src/composables/useCurriculumSubjects.js`

과목 목록을 하드코딩 fallback으로 채우지 않고 API 응답 기반으로 관리하도록 유지했습니다.

### `client/src/views/ParentDashboard.vue`

학부모 대시보드에서 자동으로 실행되던 데모 진로 검색어를 제거했습니다. 사용자가 검색하거나 API 데이터가 올 때까지 결과를 비워 둡니다.

### `client/src/views/TeacherDashboard.vue`

교사용 대시보드에서 자동으로 실행되던 데모 교육과정 검색어를 제거했습니다. API 데이터가 오기 전에는 검색 결과가 비어 있습니다.

### `client/src/views/parent/ParentCareerPage.vue`

기본 강점/관심사 문구와 기본 역량 격차 placeholder를 제거했습니다. 진로 힌트는 입력값과 API 응답을 기준으로 표시됩니다.

### `client/src/views/parent/ParentOverviewPage.vue`

하드코딩된 가정 지원 문구, 최근 변화 예시, 준비물 목록을 제거했습니다. 학교생활/피드백 데이터가 있을 때만 관련 내용이 표시됩니다.

### `client/src/views/parent/ParentSchoolPage.vue`

기본 시간표와 기본 준비물 placeholder를 제거했습니다. API 응답이 없으면 비어 있는 상태로 유지됩니다.

### `client/src/views/teacher/TeacherCareerPage.vue`

기본 현재 역량/관심사 문구를 제거하고, 페이지 진입 시 자동으로 진로 추천을 실행하지 않도록 변경했습니다.

### `client/src/views/teacher/TeacherCurriculumPage.vue`

기본 검색어와 기본 과목 선택값을 제거했습니다. 교육과정 검색은 사용자의 입력 또는 API 응답 기반으로 동작합니다.

### `client/src/views/teacher/TeacherOverviewPage.vue`

기본 관찰 기록, 기본 학생 정보, 기본 전략/활동 예시를 제거했습니다. 추천 실행 전에는 빈 추천 상태를 유지합니다.

### `client/src/views/teacher/TeacherProgressPage.vue`

피드백이 없을 때 최근 수준이 `중`으로 보이던 기본값을 제거했습니다. 실제 피드백 분석값이 있을 때만 수준을 표시합니다.

### `client/src/views/teacher/TeacherScaffoldingPage.vue`

기본 관찰 기록, 기본 학생 정보 placeholder, 기본 전략/활동/관련 성취기준 fallback을 제거했습니다.

## 충돌 처리 내용

`frontend` 브랜치에는 이미 API 응답 파싱, 추천 결과 UI, 과목 목록 composable 관련 수정이 들어가 있었기 때문에 cherry-pick 중 일부 파일에서 충돌이 발생했습니다.

충돌 파일에서는 이번 PR 목적에 맞게 “프론트엔드 내부 데모 데이터 제거” 변경을 반영하는 쪽으로 정리했습니다.

충돌이 있었던 파일:

- `client/src/App.vue`
- `client/src/api/index.js`
- `client/src/composables/useCurriculumSubjects.js`
- `client/src/views/teacher/TeacherCareerPage.vue`
- `client/src/views/teacher/TeacherOverviewPage.vue`
- `client/src/views/teacher/TeacherProgressPage.vue`
- `client/src/views/teacher/TeacherScaffoldingPage.vue`

## 검증

- `npm run build` 성공
- 최종 커밋 브랜치: `frontend`
- 최종 커밋: `2df6811 Remove frontend demo fallback data`

## 리뷰 포인트

- mock API를 연결하지 않은 상태에서 화면에 실제 데이터처럼 보이는 샘플이 남아 있지 않은지 확인해 주세요.
- mock API 응답을 연결했을 때 한 건의 학생/추천/학교생활 데이터만 정상적으로 표시되는지 확인해 주세요.
